### PR TITLE
feat: User도메인 관련 엔티티 추가

### DIFF
--- a/src/main/java/grit/guidance/domain/course/entity/Course.java
+++ b/src/main/java/grit/guidance/domain/course/entity/Course.java
@@ -9,6 +9,9 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Table(name = "course")
 @Getter
@@ -41,6 +44,14 @@ public class Course extends BaseEntity {
     @Enumerated(EnumType.STRING) // Enum타입이기 때문에 명시적 지정
     @Column(name = "open_semester", nullable = false)
     private Semester openSemester;
+
+    // 1:N 관계 - course와 completed_course (양방향)
+    @OneToMany(mappedBy = "course", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<grit.guidance.domain.user.entity.CompletedCourse> completedCourses = new ArrayList<>();
+
+    // 1:N 관계 - course와 favorite_course (양방향)
+    @OneToMany(mappedBy = "course", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<grit.guidance.domain.user.entity.FavoriteCourse> favoriteCourses = new ArrayList<>();
 
     @Builder
     public Course(String courseName, String courseCode,Integer credits, String description, Integer openGrade, Semester openSemester) {

--- a/src/main/java/grit/guidance/domain/user/entity/CompletedCourse.java
+++ b/src/main/java/grit/guidance/domain/user/entity/CompletedCourse.java
@@ -1,0 +1,71 @@
+package grit.guidance.domain.user.entity;
+
+import grit.guidance.domain.course.entity.Course;
+import grit.guidance.domain.course.entity.Semester;
+import grit.guidance.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+@Entity
+@Table(name = "completed_course")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE completed_course SET updated_at = NOW(), deleted_at = NOW() WHERE completed_course_id = ?")
+@SQLRestriction("deleted_at IS NULL")
+public class CompletedCourse extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "completed_course_id")
+    private Long id;
+
+    // N:1 관계 - completed_course와 users (양방향)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private Users users;
+
+    // N:1 관계 - completed_course와 course (단방향, course 도메인 참조)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "course_id", nullable = false)
+    private Course course;
+
+    @Column(name = "completed_year", nullable = false)
+    private Integer completedYear; // 이수년도
+
+    @Column(name = "completed_grade", nullable = false)
+    private Integer completedGrade; // 이수학년 (1-4, 추가학년은 4)
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "completed_semester", nullable = false)
+    private Semester completedSemester; // 이수학기 (1, 2, 여름학기, 계절학기)
+
+    @Builder
+    public CompletedCourse(Users users, Course course, Integer completedYear, 
+                          Integer completedGrade, Semester completedSemester) {
+        this.users = users;
+        this.course = course;
+        this.completedYear = completedYear;
+        this.completedGrade = completedGrade;
+        this.completedSemester = completedSemester;
+    }
+
+    // 비즈니스 메서드
+    public void updateCompletedInfo(Integer completedYear, Integer completedGrade, Semester completedSemester) {
+        validateCompletedGrade(completedGrade);
+        this.completedYear = completedYear;
+        this.completedGrade = completedGrade;
+        this.completedSemester = completedSemester;
+    }
+
+    private void validateCompletedGrade(Integer grade) {
+        if (grade < 1 || grade > 4) {
+            throw new IllegalArgumentException("이수학년은 1-4 범위여야 합니다.");
+        }
+    }
+}
+

--- a/src/main/java/grit/guidance/domain/user/entity/FavoriteCourse.java
+++ b/src/main/java/grit/guidance/domain/user/entity/FavoriteCourse.java
@@ -1,0 +1,50 @@
+package grit.guidance.domain.user.entity;
+
+import grit.guidance.domain.course.entity.Course;
+import grit.guidance.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+@Entity
+@Table(name = "favorite_course")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE favorite_course SET updated_at = NOW(), deleted_at = NOW() WHERE favorite_course_id = ?")
+@SQLRestriction("deleted_at IS NULL")
+public class FavoriteCourse extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "favorite_course_id")
+    private Long id;
+
+    // N:1 관계 - favorite_course와 users (양방향)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private Users users;
+
+    // N:1 관계 - favorite_course와 course (단방향, course 도메인 참조)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "course_id", nullable = false)
+    private Course course;
+
+    @Builder
+    public FavoriteCourse(Users users, Course course) {
+        this.users = users;
+        this.course = course;
+    }
+
+    // 비즈니스 메서드
+    public boolean isSameUser(Users user) {
+        return this.users.getId().equals(user.getId());
+    }
+
+    public boolean isSameCourse(Course course) {
+        return this.course.getId().equals(course.getId());
+    }
+}

--- a/src/main/java/grit/guidance/domain/user/entity/GraduationRequirement.java
+++ b/src/main/java/grit/guidance/domain/user/entity/GraduationRequirement.java
@@ -1,0 +1,64 @@
+package grit.guidance.domain.user.entity;
+
+import grit.guidance.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+@Entity
+@Table(name = "graduation_requirement")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE graduation_requirement SET updated_at = NOW(), deleted_at = NOW() WHERE graduation_requirement_id = ?")
+@SQLRestriction("deleted_at IS NULL")
+public class GraduationRequirement extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "graduation_requirement_id")
+    private Long id;
+
+    // 1:1 관계 - graduation_requirement와 users (양방향)
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    private Users users;
+
+    @Column(name = "capstone_completed", nullable = false)
+    private Boolean capstoneCompleted = false; // 캡스톤 출품 여부
+
+    @Column(name = "thesis_submitted", nullable = false)
+    private Boolean thesisSubmitted = false; // 졸업 논문 제출 여부
+
+    @Column(name = "award_or_certificate_received", nullable = false)
+    private Boolean awardOrCertificateReceived = false; // 자격증/입상 여부
+
+    @Builder
+    public GraduationRequirement(Users users, Boolean capstoneCompleted, 
+                               Boolean thesisSubmitted, Boolean awardOrCertificateReceived) {
+        this.users = users;
+        this.capstoneCompleted = capstoneCompleted != null ? capstoneCompleted : false;
+        this.thesisSubmitted = thesisSubmitted != null ? thesisSubmitted : false;
+        this.awardOrCertificateReceived = awardOrCertificateReceived != null ? awardOrCertificateReceived : false;
+    }
+
+    // 비즈니스 메서드
+    public void updateCapstoneStatus(Boolean completed) {
+        this.capstoneCompleted = completed;
+    }
+
+    public void updateThesisStatus(Boolean submitted) {
+        this.thesisSubmitted = submitted;
+    }
+
+    public void updateAwardStatus(Boolean received) {
+        this.awardOrCertificateReceived = received;
+    }
+
+    public boolean isAllRequirementsMet() {
+        return capstoneCompleted && thesisSubmitted && awardOrCertificateReceived;
+    }
+}

--- a/src/main/java/grit/guidance/domain/user/entity/Setting.java
+++ b/src/main/java/grit/guidance/domain/user/entity/Setting.java
@@ -1,0 +1,48 @@
+package grit.guidance.domain.user.entity;
+
+import grit.guidance.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+@Entity
+@Table(name = "setting")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE setting SET updated_at = NOW(), deleted_at = NOW() WHERE setting_id = ?")
+@SQLRestriction("deleted_at IS NULL")
+public class Setting extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "setting_id")
+    private Long id;
+
+    // 1:1 관계 - setting과 users (양방향)
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    private Users users;
+
+    @Column(name = "setting_info", columnDefinition = "TEXT")
+    private String settingInfo; // JSON 형태의 설정 정보 (null이면 기본 설정 적용)
+
+    @Builder
+    public Setting(Users users, String settingInfo) {
+        this.users = users;
+        this.settingInfo = settingInfo;
+    }
+
+    // 비즈니스 메서드
+    public void updateSettingInfo(String settingInfo) {
+        this.settingInfo = settingInfo;
+    }
+
+    public void resetToDefault() {
+        this.settingInfo = null; // null이면 기본 설정 JSON 적용
+    }
+}
+

--- a/src/main/java/grit/guidance/domain/user/entity/Users.java
+++ b/src/main/java/grit/guidance/domain/user/entity/Users.java
@@ -1,0 +1,73 @@
+package grit.guidance.domain.user.entity;
+
+import grit.guidance.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "users")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE users SET updated_at = NOW(), deleted_at = NOW() WHERE user_id = ?")
+@SQLRestriction("deleted_at IS NULL")
+public class Users extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long id;
+
+    @Column(name = "student_id", nullable = false, unique = true, length = 10)
+    private String studentId; // 7자리 학번
+
+    @Column(name = "GPA", nullable = false, precision = 3, scale = 2)
+    private BigDecimal gpa = BigDecimal.ZERO; // 0.0-4.5 범위
+
+    @Column(name = "timetable", columnDefinition = "TEXT")
+    private String timetable; // JSON 형태의 시간표
+
+    // 1:1 관계 - users와 setting (양방향)
+    @OneToOne(mappedBy = "users", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private Setting setting;
+
+    // 1:1 관계 - users와 graduation_requirement (양방향)
+    @OneToOne(mappedBy = "users", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private GraduationRequirement graduationRequirement;
+
+    // 1:N 관계 - users와 completed_course (양방향)
+    @OneToMany(mappedBy = "users", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<CompletedCourse> completedCourses = new ArrayList<>();
+
+    // 1:N 관계 - users와 favorite_course (양방향)
+    @OneToMany(mappedBy = "users", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<FavoriteCourse> favoriteCourses = new ArrayList<>();
+
+    @Builder
+    public Users(String studentId, BigDecimal gpa, String timetable) {
+        this.studentId = studentId;
+        this.gpa = gpa != null ? gpa : BigDecimal.ZERO;
+        this.timetable = timetable;
+    }
+
+    // 비즈니스 메서드
+    public void updateGpa(BigDecimal newGpa) {
+        if (newGpa.compareTo(BigDecimal.ZERO) < 0 || newGpa.compareTo(new BigDecimal("4.5")) > 0) {
+            throw new IllegalArgumentException("GPA는 0.0-4.5 범위여야 합니다.");
+        }
+        this.gpa = newGpa;
+    }
+
+    public void updateTimetable(String timetable) {
+        this.timetable = timetable;
+    }
+}
+


### PR DESCRIPTION
### 🚀 Summary
- Users 테이블
- CompletedCourse 테이블
- FavoriteCourse 테이블
- GraduationRequirement 테이블
- Setting 테이블
추가 및 course 도메인과의 관계 설정 완료

### ✨ Description
엔티티 파일에 비즈니스 메서드 추가했습니다. (개별 엔티티의 제약조건 등의 메서드는 서비스에 쓰면 안된다고함)
### 🎲 Issue Number
close #3
