### PR TITLE
feat: 로그인시 jwt토큰 및 크롤링 데이터 저장 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,11 @@ dependencies {
 	// .env 파일을 사용하기 위한 라이브러리
 	testImplementation 'io.github.cdimascio:java-dotenv:5.2.2'
 
+	// JWT 토큰 생성
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/grit/guidance/domain/user/controller/LoginController.java
+++ b/src/main/java/grit/guidance/domain/user/controller/LoginController.java
@@ -1,0 +1,44 @@
+package grit.guidance.domain.user.controller;
+
+import grit.guidance.domain.user.dto.ErrorResponse;
+import grit.guidance.domain.user.dto.LoginRequest;
+import grit.guidance.domain.user.dto.LoginResponse;
+import grit.guidance.domain.user.service.LoginService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+@Tag(name = "사용자", description = "사용자 관련 API")
+public class LoginController {
+
+    private final LoginService loginService;
+
+    @PostMapping("/login")
+    @Operation(summary = "로그인", description = "기존 사용자면 초기 화면 정보를 전달")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "201", description = "로그인 성공"),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청 (사용자 이름/비밀번호 누락 또는 잘못된 비밀번호)"),
+        @ApiResponse(responseCode = "404", description = "회원 정보를 찾을 수 없습니다")
+    })
+    public ResponseEntity<?> login(@RequestBody LoginRequest request) {
+        try {
+            LoginResponse response = loginService.login(request);
+            return ResponseEntity.status(response.status()).body(response);
+        } catch (IllegalArgumentException e) {
+            // 400 Bad Request
+            ErrorResponse errorResponse = new ErrorResponse(400, e.getMessage());
+            return ResponseEntity.badRequest().body(errorResponse);
+        } catch (RuntimeException e) {
+            // 404 Not Found
+            ErrorResponse errorResponse = new ErrorResponse(404, e.getMessage());
+            return ResponseEntity.status(404).body(errorResponse);
+        }
+    }
+}

--- a/src/main/java/grit/guidance/domain/user/dto/ErrorResponse.java
+++ b/src/main/java/grit/guidance/domain/user/dto/ErrorResponse.java
@@ -1,0 +1,11 @@
+package grit.guidance.domain.user.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record ErrorResponse(
+    @JsonProperty("status")
+    Integer status,
+    @JsonProperty("message")
+    String message
+) {
+}

--- a/src/main/java/grit/guidance/domain/user/dto/LoginRequest.java
+++ b/src/main/java/grit/guidance/domain/user/dto/LoginRequest.java
@@ -1,0 +1,10 @@
+package grit.guidance.domain.user.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record LoginRequest(
+    @JsonProperty("student_id")
+    String studentId,
+    String password
+) {
+}

--- a/src/main/java/grit/guidance/domain/user/dto/LoginResponse.java
+++ b/src/main/java/grit/guidance/domain/user/dto/LoginResponse.java
@@ -1,0 +1,11 @@
+package grit.guidance.domain.user.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record LoginResponse(
+    @JsonProperty("status")
+    Integer status,
+    @JsonProperty("access_token")
+    String accessToken
+) {
+}

--- a/src/main/java/grit/guidance/domain/user/service/UserDetailsServiceImpl.java
+++ b/src/main/java/grit/guidance/domain/user/service/UserDetailsServiceImpl.java
@@ -1,0 +1,32 @@
+package grit.guidance.domain.user.service;
+
+import grit.guidance.domain.user.entity.Users;
+import grit.guidance.domain.user.repository.UsersRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+
+@Service
+@RequiredArgsConstructor
+public class UserDetailsServiceImpl implements UserDetailsService {
+
+    private final UsersRepository usersRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String studentId) throws UsernameNotFoundException {
+        Users user = usersRepository.findByStudentId(studentId)
+                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다: " + studentId));
+
+        return new User(
+                user.getStudentId(),
+                "", // 비밀번호는 JWT에서 검증하므로 빈 문자열
+                Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"))
+        );
+    }
+}

--- a/src/main/java/grit/guidance/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/grit/guidance/global/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,95 @@
+package grit.guidance.global.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.lang.NonNull;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+/**
+ * JWT 인증 필터
+ * - HTTP 요청에서 JWT 토큰을 추출하고 인증 처리
+ * - Authorization: Bearer <token> 헤더에서 토큰 추출
+ * - 토큰 유효성 검증 후 Spring Security 컨텍스트에 인증 정보 설정
+ */
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtService jwtService; // JWT 토큰 처리 서비스
+    private final UserDetailsService userDetailsService; // 사용자 정보 로드 서비스
+
+    /**
+     * JWT 인증 필터 메인 로직
+     * 1. Authorization 헤더에서 Bearer 토큰 추출
+     * 2. 토큰에서 학번 추출
+     * 3. 토큰 유효성 검증
+     * 4. Spring Security 컨텍스트에 인증 정보 설정
+     */
+    @Override
+    protected void doFilterInternal(
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull FilterChain filterChain
+    ) throws ServletException, IOException {
+        
+        // 1. Authorization 헤더에서 JWT 토큰 추출
+        final String authHeader = request.getHeader("Authorization");
+        final String jwt;
+        final String studentId;
+
+        // Bearer 토큰이 없으면 다음 필터로 넘어감
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        // 2. "Bearer " 접두사 제거하고 실제 토큰 추출
+        jwt = authHeader.substring(7);
+        try {
+            // 3. 토큰에서 학번 추출
+            studentId = jwtService.getStudentIdFromToken(jwt);
+        } catch (Exception e) {
+            // 토큰 파싱 실패 시 다음 필터로 넘어감
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        // 4. 학번이 있고 아직 인증되지 않은 경우에만 인증 처리
+        if (studentId != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+            // 사용자 정보 로드
+            UserDetails userDetails = this.userDetailsService.loadUserByUsername(studentId);
+            
+            // 토큰 유효성 검증
+            if (jwtService.validateToken(jwt)) {
+                // Spring Security 인증 토큰 생성
+                UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
+                        userDetails,
+                        null, // 비밀번호는 JWT에서 검증했으므로 null
+                        userDetails.getAuthorities() // 사용자 권한 설정
+                );
+                
+                // 요청 세부 정보 설정
+                authToken.setDetails(
+                        new WebAuthenticationDetailsSource().buildDetails(request)
+                );
+                
+                // Spring Security 컨텍스트에 인증 정보 설정
+                SecurityContextHolder.getContext().setAuthentication(authToken);
+            }
+        }
+        
+        // 다음 필터로 요청 전달
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/grit/guidance/global/jwt/JwtService.java
+++ b/src/main/java/grit/guidance/global/jwt/JwtService.java
@@ -1,0 +1,81 @@
+package grit.guidance.global.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.SecretKey;
+import java.util.Date;
+
+/**
+ * JWT 토큰 생성, 검증, 파싱을 담당하는 서비스
+ * - Access Token 생성 및 검증
+ * - 토큰에서 사용자 정보 추출
+ */
+@Service
+public class JwtService {
+
+    @Value("${jwt.secret:mySecretKey123456789012345678901234567890}")
+    private String secret; // JWT 서명에 사용할 비밀키
+
+    @Value("${jwt.expiration:86400000}") // 24시간 (밀리초)
+    private Long expiration; // 토큰 만료 시간
+
+    /**
+     * JWT 서명에 사용할 SecretKey 생성
+     * @return HMAC SHA 키
+     */
+    private SecretKey getSigningKey() {
+        return Keys.hmacShaKeyFor(secret.getBytes());
+    }
+
+    /**
+     * 학번을 기반으로 JWT Access Token 생성
+     * @param studentId 사용자 학번
+     * @return 생성된 JWT 토큰 문자열
+     */
+    public String generateToken(String studentId) {
+        Date now = new Date();
+        Date expiryDate = new Date(now.getTime() + expiration);
+
+        return Jwts.builder()
+                .subject(studentId) // 토큰 주체 (학번)
+                .issuedAt(now) // 발급 시간
+                .expiration(expiryDate) // 만료 시간
+                .signWith(getSigningKey()) // 서명
+                .compact(); // 문자열로 변환
+    }
+
+    /**
+     * JWT 토큰에서 학번 추출
+     * @param token JWT 토큰 문자열
+     * @return 추출된 학번
+     */
+    public String getStudentIdFromToken(String token) {
+        Claims claims = Jwts.parser()
+                .verifyWith(getSigningKey()) // 서명 검증
+                .build()
+                .parseSignedClaims(token) // 토큰 파싱
+                .getPayload(); // 페이로드 추출
+        return claims.getSubject(); // 학번 반환
+    }
+
+    /**
+     * JWT 토큰 유효성 검증
+     * @param token 검증할 JWT 토큰
+     * @return 유효하면 true, 그렇지 않으면 false
+     */
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parser()
+                    .verifyWith(getSigningKey()) // 서명 검증
+                    .build()
+                    .parseSignedClaims(token); // 토큰 파싱
+            return true; // 파싱 성공 시 유효한 토큰
+        } catch (Exception e) {
+            return false; // 파싱 실패 시 유효하지 않은 토큰
+        }
+    }
+}

--- a/src/main/java/grit/guidance/global/jwt/JwtToken.java
+++ b/src/main/java/grit/guidance/global/jwt/JwtToken.java
@@ -1,0 +1,25 @@
+package grit.guidance.global.jwt;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * JWT 토큰 정보를 담는 DTO
+ * - Access Token만 포함 (Refresh Token 제외)
+ * - JSON 응답 시 snake_case로 변환 (access_token)
+ */
+@Builder
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class JwtToken {
+    @JsonProperty("access_token")
+    private String accessToken; // JWT Access Token
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -3,7 +3,7 @@ spring:
     import: optional:file:.env[.properties]
 
   datasource:
-    url: ${POSTGRES_URL:jdbc:postgresql://localhost:5432/database}
+    url: ${POSTGRES_URL:jdbc:postgresql://db:5432/database}
     username: ${POSTGRES_USER:sa}
     password: ${POSTGRES_PASSWORD:1234}
     driver-class-name: org.postgresql.Driver


### PR DESCRIPTION
### 🚀 Summary
jwt토큰 유효시간 24시간으로 설정 했습니다.
로그인 시 크롤링하여 유저트랙, 이수과목 테이블 채우는 로직 구현

### ✨ Description
이수과목 테이블
<img width="1736" height="588" alt="image" src="https://github.com/user-attachments/assets/af50a77f-b75c-4ab2-bf02-783c4d961b5a" />

트랙 테이블
*본인의 2트랙이 ai라서 다른 분들의 테스팅 요망
<img width="1788" height="102" alt="image" src="https://github.com/user-attachments/assets/89702f49-0ad0-4673-bbb4-cde888db3aa4" />

로그인 후 토큰 발급
<img width="1911" height="369" alt="image" src="https://github.com/user-attachments/assets/e0772c3d-6b21-4bb4-9d9b-c0b8d9806812" />


### 🎲 Issue Number
close #11 
