### PR TITLE
[feat] 수강중인 과목 크롤링 및 저장 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,9 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 
+	// 세션을 자동으로 관리하는 RestTemplate을 만들기 위해 필요
+	implementation 'org.apache.httpcomponents.client5:httpclient5'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/grit/guidance/domain/course/repository/CourseRepository.java
+++ b/src/main/java/grit/guidance/domain/course/repository/CourseRepository.java
@@ -9,4 +9,5 @@ import java.util.Optional;
 @Repository
 public interface CourseRepository extends JpaRepository<Course, Long> {
     Optional<Course> findByCourseCode(String courseCode);
+    Optional<Course> findByCourseName(String courseName);
 }

--- a/src/main/java/grit/guidance/domain/user/dto/HansungDataResponse.java
+++ b/src/main/java/grit/guidance/domain/user/dto/HansungDataResponse.java
@@ -1,4 +1,6 @@
 package grit.guidance.domain.user.dto;
 
+import java.util.List;
+
 // 최종 크롤링 결과를 담는 DTO
-public record HansungDataResponse(UserInfoResponse userInfo, TotalGradeResponse grades) {}
+public record HansungDataResponse(UserInfoResponse userInfo, TotalGradeResponse grades, List<String> enrolledCourseNames) {}

--- a/src/main/java/grit/guidance/domain/user/dto/TimetableEventDto.java
+++ b/src/main/java/grit/guidance/domain/user/dto/TimetableEventDto.java
@@ -1,0 +1,7 @@
+package grit.guidance.domain.user.dto;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record TimetableEventDto(
+    @JsonProperty("title")
+    String title
+) {}

--- a/src/main/java/grit/guidance/domain/user/entity/EnrolledCourse.java
+++ b/src/main/java/grit/guidance/domain/user/entity/EnrolledCourse.java
@@ -32,18 +32,9 @@ public class EnrolledCourse extends BaseEntity {
     @JoinColumn(name = "course_id", nullable = false)
     private Course course;
 
-    @Column(name = "enrolled_year", nullable = false)
-    private Integer enrolledYear; // 수강 년도
-
-    @Enumerated(EnumType.STRING)
-    @Column(name = "enrolled_semester", nullable = false)
-    private Semester enrolledSemester; // 수강 학기
-
     @Builder
-    private EnrolledCourse(Users user, Course course, Integer enrolledYear, Semester enrolledSemester) {
+    private EnrolledCourse(Users user, Course course) {
         this.user = user;
         this.course = course;
-        this.enrolledYear = enrolledYear;
-        this.enrolledSemester = enrolledSemester;
     }
 }

--- a/src/main/java/grit/guidance/domain/user/entity/EnrolledCourse.java
+++ b/src/main/java/grit/guidance/domain/user/entity/EnrolledCourse.java
@@ -1,0 +1,49 @@
+package grit.guidance.domain.user.entity;
+
+import grit.guidance.domain.course.entity.Course;
+import grit.guidance.domain.course.entity.Semester;
+import grit.guidance.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+@Entity
+@Table(name = "enrolled_course")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE enrolled_course SET updated_at = NOW(), deleted_at = NOW() WHERE enrolled_course_id = ?")
+@SQLRestriction("deleted_at IS NULL")
+public class EnrolledCourse extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "enrolled_course_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private Users user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "course_id", nullable = false)
+    private Course course;
+
+    @Column(name = "enrolled_year", nullable = false)
+    private Integer enrolledYear; // 수강 년도
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "enrolled_semester", nullable = false)
+    private Semester enrolledSemester; // 수강 학기
+
+    @Builder
+    private EnrolledCourse(Users user, Course course, Integer enrolledYear, Semester enrolledSemester) {
+        this.user = user;
+        this.course = course;
+        this.enrolledYear = enrolledYear;
+        this.enrolledSemester = enrolledSemester;
+    }
+}

--- a/src/main/java/grit/guidance/domain/user/repository/EnrolledCourseRepository.java
+++ b/src/main/java/grit/guidance/domain/user/repository/EnrolledCourseRepository.java
@@ -1,0 +1,11 @@
+package grit.guidance.domain.user.repository;
+
+import grit.guidance.domain.user.entity.EnrolledCourse;
+import grit.guidance.domain.user.entity.Users;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface EnrolledCourseRepository extends JpaRepository<EnrolledCourse, Long> {
+    void deleteByUser(Users user);
+}

--- a/src/main/java/grit/guidance/domain/user/service/CrawlingConditionService.java
+++ b/src/main/java/grit/guidance/domain/user/service/CrawlingConditionService.java
@@ -23,41 +23,42 @@ public class CrawlingConditionService {
      * @return 크롤링 필요 여부
      */
     public boolean shouldCrawl(Users user) {
-        // 1. DB에 없던 유저가 로그인 시 -> 크롤링 필요
-        if (user == null) {
-            log.info("신규 사용자 로그인 - 크롤링 필요");
-            return true;
-        }
-
-        // 2. 기존 유저 로그인 시
-        LocalDateTime now = LocalDateTime.now();
-
-        // 2-1. last_crawl_time 확인 후 한 달 이상 지났으면 크롤링
-        LocalDateTime userLastCrawl = user.getLastCrawlTime();
-        if (userLastCrawl != null) {
-            long daysSinceLastCrawl = ChronoUnit.DAYS.between(userLastCrawl, now);
-            if (daysSinceLastCrawl >= 30) {
-                log.info("사용자 마지막 크롤링으로부터 {}일 경과 - 크롤링 필요", daysSinceLastCrawl);
-                return true;
-            }
-        } else {
-            // last_crawl_time이 null이면 크롤링 필요 (기존 데이터가 없음)
-            log.info("사용자 last_crawl_time이 null - 크롤링 필요");
-            return true;
-        }
-
-        // 2-2. system_data 테이블의 global_update_time과 비교
-        SystemData systemData = getSystemData();
-        if (systemData != null) {
-            LocalDateTime globalUpdateTime = systemData.getGlobalUpdateTime();
-            if (globalUpdateTime != null && globalUpdateTime.isAfter(userLastCrawl)) {
-                log.info("글로벌 업데이트 시간({})이 사용자 마지막 크롤링({})보다 최근 - 크롤링 필요", globalUpdateTime, userLastCrawl);
-                return true;
-            }
-        }
-
-        log.info("크롤링 불필요 - 기존 데이터 사용");
-        return false;
+//        // 1. DB에 없던 유저가 로그인 시 -> 크롤링 필요
+//        if (user == null) {
+//            log.info("신규 사용자 로그인 - 크롤링 필요");
+//            return true;
+//        }
+//
+//        // 2. 기존 유저 로그인 시
+//        LocalDateTime now = LocalDateTime.now();
+//
+//        // 2-1. last_crawl_time 확인 후 한 달 이상 지났으면 크롤링
+//        LocalDateTime userLastCrawl = user.getLastCrawlTime();
+//        if (userLastCrawl != null) {
+//            long daysSinceLastCrawl = ChronoUnit.DAYS.between(userLastCrawl, now);
+//            if (daysSinceLastCrawl >= 30) {
+//                log.info("사용자 마지막 크롤링으로부터 {}일 경과 - 크롤링 필요", daysSinceLastCrawl);
+//                return true;
+//            }
+//        } else {
+//            // last_crawl_time이 null이면 크롤링 필요 (기존 데이터가 없음)
+//            log.info("사용자 last_crawl_time이 null - 크롤링 필요");
+//            return true;
+//        }
+//
+//        // 2-2. system_data 테이블의 global_update_time과 비교
+//        SystemData systemData = getSystemData();
+//        if (systemData != null) {
+//            LocalDateTime globalUpdateTime = systemData.getGlobalUpdateTime();
+//            if (globalUpdateTime != null && globalUpdateTime.isAfter(userLastCrawl)) {
+//                log.info("글로벌 업데이트 시간({})이 사용자 마지막 크롤링({})보다 최근 - 크롤링 필요", globalUpdateTime, userLastCrawl);
+//                return true;
+//            }
+//        }
+//
+//        log.info("크롤링 불필요 - 기존 데이터 사용");
+//        return false;
+        return true;
     }
 
     /**

--- a/src/main/java/grit/guidance/global/config/AppConfig.java
+++ b/src/main/java/grit/guidance/global/config/AppConfig.java
@@ -1,13 +1,28 @@
 package grit.guidance.global.config;
 
+import org.apache.hc.client5.http.classic.HttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.client5.http.cookie.CookieStore;
+import org.apache.hc.client5.http.cookie.BasicCookieStore;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 
 @Configuration
 public class AppConfig {
+
     @Bean
     public RestTemplate restTemplate() {
-        return new RestTemplate();
+        CookieStore cookieStore = new BasicCookieStore();
+        HttpClient httpClient = HttpClientBuilder.create()
+                .setDefaultCookieStore(cookieStore)
+                .disableRedirectHandling()
+                .setUserAgent("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36")
+                .build();
+
+        HttpComponentsClientHttpRequestFactory requestFactory = new HttpComponentsClientHttpRequestFactory(httpClient);
+
+        return new RestTemplate(requestFactory);
     }
 }


### PR DESCRIPTION
### 🚀 Summary

<!-- A brief description of the issue. -->

수강중인 과목 크롤링 및 저장 기능 구현

### ✨ Description

<!-- write down the work details and show the execution results. -->

- enrolled_course(수강중인 과목) 테이블 추가
- 종정시 개인시간표 조회하여 서버 db(전공과목들)을 비교하여 이름이 같으면 enrolled_course 테이블에 저장
<img width="1205" height="179" alt="image" src="https://github.com/user-attachments/assets/aa4caf69-be40-4783-b102-e38d95f551ca" />
현재 4전공이라 4개 저장 완료. course에 모든 교양을 저장할 순 없으니교양은 레코드를 추가하거나 테이블을 따로 만들 예정 tl

### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #{22}
