### PR TITLE
세부 과목 다 나오도록 기능개발 완료

### DIFF
--- a/src/main/java/grit/guidance/domain/graduation/dto/DetailedCreditDto.java
+++ b/src/main/java/grit/guidance/domain/graduation/dto/DetailedCreditDto.java
@@ -1,17 +1,15 @@
 package grit.guidance.domain.graduation.dto;
 
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-@Data
+@Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class DetailedCreditDto {
-    private int completedCredits;
-    private int requiredCredits;
-    private int remainingCredits;
-    private double progressRate;
+    private Integer completedCredits;
+    private Integer requiredCredits;
 }

--- a/src/main/java/grit/guidance/domain/graduation/dto/TrackProgressDto.java
+++ b/src/main/java/grit/guidance/domain/graduation/dto/TrackProgressDto.java
@@ -1,21 +1,18 @@
 package grit.guidance.domain.graduation.dto;
 
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-@Data
+@Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class TrackProgressDto {
     private String trackName;
     private String category;
-    private int completedCredits;
-    private int requiredCredits;
-    private int remainingCredits;
-    private double progressRate;
     private DetailedCreditDto majorBasic;
     private DetailedCreditDto majorRequired;
+    private DetailedCreditDto majorSubtotal; // 기존 필드 대신 상세 DTO로 변경
 }

--- a/src/main/java/grit/guidance/domain/graduation/service/GraduationService.java
+++ b/src/main/java/grit/guidance/domain/graduation/service/GraduationService.java
@@ -1,8 +1,7 @@
-// GraduationService.java
-
 package grit.guidance.domain.graduation.service;
 
 import grit.guidance.domain.graduation.dto.CertificationStatusDto;
+import grit.guidance.domain.graduation.dto.DetailedCreditDto;
 import grit.guidance.domain.graduation.dto.GraduationResponseDto;
 import grit.guidance.domain.graduation.dto.TrackProgressDto;
 import grit.guidance.domain.graduation.entity.CrawlingGraduation;
@@ -34,11 +33,11 @@ public class GraduationService {
         Users user = usersRepository.findByStudentId(studentId)
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다. 학번: " + studentId));
 
-        // ⭐ 1. 크롤링된 학점 정보 조회
+        // 1. 크롤링된 학점 정보 조회
         CrawlingGraduation crawlingData = crawlingGraduationRepository.findByUsers(user)
                 .orElseThrow(() -> new IllegalStateException("크롤링된 졸업 데이터를 찾을 수 없습니다. 먼저 크롤링을 수행해주세요."));
 
-        // ⭐ 2. 졸업 인증 요건 조회
+        // 2. 졸업 인증 요건 조회
         GraduationRequirement requirement = graduationRequirementRepository.findByUsers(user)
                 .orElse(GraduationRequirement.builder()
                         .users(user)
@@ -47,42 +46,77 @@ public class GraduationService {
                         .awardOrCertificateReceived(false)
                         .build());
 
-        // ⭐ 3. 트랙별 진행률 계산 및 DTO 생성 (크롤링 데이터 활용)
+        // 3. 트랙별 DTO 생성 (크롤링 데이터 활용)
         List<String> orderedTrackNames = userTrackRepository.findByUsers(user).stream()
                 .sorted((a, b) -> a.getTrackType().name().compareTo(b.getTrackType().name()))
                 .map(ut -> ut.getTrack().getTrackName())
                 .toList();
 
-        final int REQUIRED_PER_TRACK = 39;
+        // 트랙1 상세 학점
+        DetailedCreditDto track1MajorBasic = DetailedCreditDto.builder()
+                .completedCredits(crawlingData.getTrack1MajorBasic())
+                .requiredCredits(3)
+                .build();
 
+        DetailedCreditDto track1MajorRequired = DetailedCreditDto.builder()
+                .completedCredits(crawlingData.getTrack1MajorRequired())
+                .requiredCredits(15)
+                .build();
+
+        DetailedCreditDto track1MajorSubtotal = DetailedCreditDto.builder()
+                .completedCredits(crawlingData.getTrack1MajorSubtotal())
+                .requiredCredits(39)
+                .build();
+
+        // 트랙1 진행 상황
         TrackProgressDto track1Progress = TrackProgressDto.builder()
                 .trackName(orderedTrackNames.get(0))
                 .category("트랙")
-                .completedCredits(crawlingData.getTrack1MajorSubtotal())
-                .requiredCredits(REQUIRED_PER_TRACK)
-                .remainingCredits(Math.max(0, REQUIRED_PER_TRACK - crawlingData.getTrack1MajorSubtotal()))
-                .progressRate((double) crawlingData.getTrack1MajorSubtotal() * 100 / REQUIRED_PER_TRACK)
+                .majorBasic(track1MajorBasic)
+                .majorRequired(track1MajorRequired)
+                .majorSubtotal(track1MajorSubtotal)
                 .build();
 
+        // 트랙2 상세 학점
+        DetailedCreditDto track2MajorBasic = DetailedCreditDto.builder()
+                .completedCredits(crawlingData.getTrack2MajorBasic())
+                .requiredCredits(3)
+                .build();
+
+        DetailedCreditDto track2MajorRequired = DetailedCreditDto.builder()
+                .completedCredits(crawlingData.getTrack2MajorRequired())
+                .requiredCredits(15)
+                .build();
+
+        DetailedCreditDto track2MajorSubtotal = DetailedCreditDto.builder()
+                .completedCredits(crawlingData.getTrack2MajorSubtotal())
+                .requiredCredits(39)
+                .build();
+
+        // 트랙2 진행 상황
         TrackProgressDto track2Progress = TrackProgressDto.builder()
                 .trackName(orderedTrackNames.get(1))
                 .category("트랙")
-                .completedCredits(crawlingData.getTrack2MajorSubtotal())
-                .requiredCredits(REQUIRED_PER_TRACK)
-                .remainingCredits(Math.max(0, REQUIRED_PER_TRACK - crawlingData.getTrack2MajorSubtotal()))
-                .progressRate((double) crawlingData.getTrack2MajorSubtotal() * 100 / REQUIRED_PER_TRACK)
+                .majorBasic(track2MajorBasic)
+                .majorRequired(track2MajorRequired)
+                .majorSubtotal(track2MajorSubtotal)
                 .build();
 
         List<TrackProgressDto> trackProgressList = List.of(track1Progress, track2Progress);
 
-        // ⭐ 4. 졸업 인증 상태 DTO 생성
+        // 4. 졸업 인증 상태 DTO 생성
         List<CertificationStatusDto> certifications = List.of(
                 CertificationStatusDto.builder().certificationName("캡스톤디자인 발표회 작품 출품").isCompleted(requirement.getCapstoneCompleted()).build(),
                 CertificationStatusDto.builder().certificationName("졸업 논문").isCompleted(requirement.getThesisSubmitted()).build(),
                 CertificationStatusDto.builder().certificationName("전공 관련 자격증/공모전 입상").isCompleted(requirement.getAwardOrCertificateReceived()).build()
         );
 
-        // ⭐ 5. 최종 응답 DTO 생성 및 반환
-        return GraduationResponseDto.from(crawlingData, trackProgressList, certifications);
+        // 5. 최종 응답 DTO 생성 및 반환
+        return GraduationResponseDto.builder()
+                .totalCompletedCredits(crawlingData.getTotalCompletedCredits())
+                .totalRequiredCredits(crawlingData.getTotalMajorRequired())
+                .trackProgressList(trackProgressList)
+                .certifications(certifications)
+                .build();
     }
 }


### PR DESCRIPTION
### 🚀 Summary

<!-- A brief description of the issue. -->

---  전공 기초 / 전공 필수 / 전공 소계 값을 크롤링한 데이터로 그대로 나오도록 구현 완료

### ✨ Description

<!-- write down the work details and show the execution results. -->

--- 그전에는 자꾸 제미나이가 이상한 식으로 계산하게 만들었었는데 로그인 하면 UserAcademicInfoSyncService를 실행시켜서 크롤링을 진행한후 데이터를 dto에 저장. 테이블에 crawling_graduation에 저장하고 이 데이터를 직접 json으로 나타냄. 각 트랙은 로그인시 학번에 track_id를 통해 나타냄

### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #{Issue Number}
