### PR TITLE
[feat] rag 기반 ai추천 로드맵 생성 기능 v1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,8 @@ dependencies {
 
 	// DataBase
 	runtimeOnly 'org.postgresql:postgresql'
+	runtimeOnly 'com.h2database:h2'
+	testRuntimeOnly 'com.h2database:h2'
 
 	// Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
@@ -56,7 +58,7 @@ dependencies {
 	implementation 'org.jsoup:jsoup:1.17.2'
 
 	// .env 파일을 사용하기 위한 라이브러리
-	testImplementation 'io.github.cdimascio:java-dotenv:5.2.2'
+	implementation 'io.github.cdimascio:java-dotenv:5.2.2'
 
 	// JWT 토큰 생성
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'

--- a/src/main/java/grit/guidance/domain/course/entity/Course.java
+++ b/src/main/java/grit/guidance/domain/course/entity/Course.java
@@ -64,10 +64,9 @@ public class Course extends BaseEntity {
         this.openSemester = openSemester;
     }
 
-    /**
-     * 과목 설명 업데이트
-     */
+    // 과목 설명 업데이트
     public void updateDescription(String description) {
         this.description = description;
     }
+
 }

--- a/src/main/java/grit/guidance/domain/course/repository/TrackRequirementRepository.java
+++ b/src/main/java/grit/guidance/domain/course/repository/TrackRequirementRepository.java
@@ -4,6 +4,7 @@ import grit.guidance.domain.course.entity.TrackRequirement;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -12,6 +13,13 @@ import java.util.List;
 public interface TrackRequirementRepository extends JpaRepository<TrackRequirement, Long> {
     // 특정 트랙의 졸업 요건(필수 과목 리스트) 가져오기
     List<TrackRequirement> findByTrackId(Long trackId);
+    
+    // 특정 과목의 트랙 요구사항 가져오기
+    List<TrackRequirement> findByCourseId(Long courseId);
+    
+    // 여러 트랙의 전공필수/전공기초 과목 조회
+    @Query("SELECT tr FROM TrackRequirement tr WHERE tr.track.id IN :trackIds AND tr.courseType IN ('MANDATORY', 'FOUNDATION') AND tr.deletedAt IS NULL")
+    List<TrackRequirement> findByTrackIdsAndCourseType(@Param("trackIds") List<Long> trackIds);
     
     @Modifying
     @Query("UPDATE TrackRequirement tr SET tr.deletedAt = CURRENT_TIMESTAMP WHERE tr.deletedAt IS NULL")

--- a/src/main/java/grit/guidance/domain/roadmap/controller/RoadmapController.java
+++ b/src/main/java/grit/guidance/domain/roadmap/controller/RoadmapController.java
@@ -2,8 +2,11 @@ package grit.guidance.domain.roadmap.controller;
 
 import grit.guidance.domain.roadmap.service.CourseEmbeddingService;
 import grit.guidance.domain.roadmap.repository.QdrantRepository;
+import grit.guidance.domain.roadmap.dto.SearchRequest;
+import grit.guidance.domain.roadmap.dto.CourseRecommendationRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.AllArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
@@ -14,6 +17,7 @@ import java.util.List;
 import java.util.Map;
 
 @RestController
+@AllArgsConstructor
 @RequestMapping("/api/roadmap")
 @Tag(name = "Roadmap", description = "로드맵 추천 API")
 public class RoadmapController {
@@ -22,11 +26,6 @@ public class RoadmapController {
     
     private final CourseEmbeddingService courseEmbeddingService;
     private final QdrantRepository qdrantRepository;
-    
-    public RoadmapController(CourseEmbeddingService courseEmbeddingService, QdrantRepository qdrantRepository) {
-        this.courseEmbeddingService = courseEmbeddingService;
-        this.qdrantRepository = qdrantRepository;
-    }
 
     @PostMapping("/courses/embed")
     @Operation(summary = "과목 데이터 벡터화 및 저장", description = "Course 테이블의 모든 과목을 Qdrant에 벡터화하여 저장합니다.")
@@ -51,18 +50,17 @@ public class RoadmapController {
         }
     }
 
-    @GetMapping("/courses/search")
+    @PostMapping("/courses/search")
     @Operation(summary = "과목 검색", description = "Qdrant에서 유사한 과목을 검색합니다.")
-    public ResponseEntity<Map<String, Object>> searchCourses(
-            @RequestParam String query,
-            @RequestParam(defaultValue = "5") int topK) {
+    public ResponseEntity<Map<String, Object>> searchCourses(@RequestBody SearchRequest request) {
         try {
-            log.info("과목 검색 요청: {} (상위 {}개)", query, topK);
+            int topK = 20;  // 고정값으로 20개 설정
+            log.info("🔍 RoadmapController 검색 요청: query='{}', topK={}", request.getQuery(), topK);
 
-            List<Map<String, Object>> results = courseEmbeddingService.searchCourses(query, topK);
+            List<Map<String, Object>> results = courseEmbeddingService.searchCoursesByPreference(request.getQuery(), topK);
 
             Map<String, Object> response = new HashMap<>();
-            response.put("query", query);
+            response.put("query", request.getQuery());
             response.put("topK", topK);
             response.put("results", results);
             response.put("count", results.size());
@@ -71,7 +69,7 @@ public class RoadmapController {
             return ResponseEntity.ok(response);
 
         } catch (Exception e) {
-            log.error("과목 검색 실패: {}", query, e);
+            log.error("과목 검색 실패: {}", request.getQuery(), e);
             return ResponseEntity.internalServerError().body(Map.of(
                     "message", "과목 검색 중 오류가 발생했습니다.",
                     "error", e.getMessage(),
@@ -98,6 +96,66 @@ public class RoadmapController {
             log.error("Qdrant 상태 확인 실패", e);
             return ResponseEntity.internalServerError().body(Map.of(
                     "message", "Qdrant 상태 확인 중 오류가 발생했습니다.",
+                    "error", e.getMessage(),
+                    "status", "error"
+            ));
+        }
+    }
+
+    @PostMapping("/courses/recommend")
+    @Operation(summary = "과목 추천", description = "사용자의 트랙과 학습 스타일에 따라 과목을 추천합니다.")
+    public ResponseEntity<Map<String, Object>> recommendCourses(@RequestBody CourseRecommendationRequest request) {
+        try {
+            log.info("🎯 과목 추천 요청: studentId={}, trackIds={}, learningStyle={}, advancedSettings={}", 
+                    request.getStudentId(), request.getTrackIds(), request.getLearningStyle(), request.getAdvancedSettings());
+
+            // 1단계: 필수 과목 목록 확보 (규칙 기반 필터링)
+            List<Map<String, Object>> mandatoryCourses = courseEmbeddingService.getMandatoryCourses(request.getTrackIds(), request.getStudentId());
+            
+            // 2단계: 벡터 DB 검색 목록 확보 (유사도 검색)
+            List<Map<String, Object>> recommendedCourses = courseEmbeddingService.getRecommendedCourses(
+                    request.getTrackIds(), request.getStudentId(), request.getLearningStyle(), request.getAdvancedSettings());
+
+            Map<String, Object> response = new HashMap<>();
+            response.put("studentId", request.getStudentId());
+            response.put("trackIds", request.getTrackIds());
+            response.put("learningStyle", request.getLearningStyle());
+            response.put("advancedSettings", request.getAdvancedSettings());
+            response.put("mandatoryCourses", mandatoryCourses);
+            response.put("recommendedCourses", recommendedCourses);
+            response.put("mandatoryCount", mandatoryCourses.size());
+            response.put("recommendedCount", recommendedCourses.size());
+            response.put("status", "success");
+
+            return ResponseEntity.ok(response);
+
+        } catch (Exception e) {
+            log.error("과목 추천 실패: trackIds={}, learningStyle={}", request.getTrackIds(), request.getLearningStyle(), e);
+            return ResponseEntity.internalServerError().body(Map.of(
+                    "message", "과목 추천 중 오류가 발생했습니다.",
+                    "error", e.getMessage(),
+                    "status", "error"
+            ));
+        }
+    }
+
+    @PostMapping("/courses/roadmap")
+    @Operation(summary = "통합 로드맵 추천", description = "1단계 필수과목 + 2단계 유사도검색 + LLM 로드맵 추천을 통합합니다.")
+    public ResponseEntity<Map<String, Object>> recommendRoadmap(@RequestBody CourseRecommendationRequest request) {
+        try {
+            log.info("🎯 통합 로드맵 추천 요청: studentId={}, trackIds={}, learningStyle={}, advancedSettings={}", 
+                    request.getStudentId(), request.getTrackIds(), request.getLearningStyle(), request.getAdvancedSettings());
+
+            // 통합 로드맵 추천 (1단계 + 2단계 + LLM)
+            Map<String, Object> response = courseEmbeddingService.getIntegratedRoadmapRecommendation(
+                    request.getTrackIds(), request.getStudentId(), request.getLearningStyle(), request.getAdvancedSettings());
+
+            return ResponseEntity.ok(response);
+
+        } catch (Exception e) {
+            log.error("통합 로드맵 추천 실패: trackIds={}, learningStyle={}", request.getTrackIds(), request.getLearningStyle(), e);
+            return ResponseEntity.internalServerError().body(Map.of(
+                    "message", "통합 로드맵 추천 중 오류가 발생했습니다.",
                     "error", e.getMessage(),
                     "status", "error"
             ));

--- a/src/main/java/grit/guidance/domain/roadmap/dto/CourseRecommendationRequest.java
+++ b/src/main/java/grit/guidance/domain/roadmap/dto/CourseRecommendationRequest.java
@@ -1,0 +1,47 @@
+package grit.guidance.domain.roadmap.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CourseRecommendationRequest {
+    @JsonProperty("student_id")
+    private String studentId;  // 학번 (예: "2191232")
+    
+    @JsonProperty("track_ids")
+    private List<Long> trackIds;  // [1, 2] - 모바일소프트웨어, 웹공학
+    
+    @JsonProperty("learning_style")
+    private LearningStyle learningStyle;
+    
+    @JsonProperty("advanced_settings")
+    private AdvancedSettings advancedSettings;  // Optional
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class LearningStyle {
+        @JsonProperty("credits_per_semester")
+        private String creditsPerSemester;  // "RELAXED", "NORMAL", "INTENSIVE"
+        
+        @JsonProperty("style_preference")
+        private String stylePreference;     // "THEORY", "BALANCED", "PRACTICE"
+        
+        @JsonProperty("ratio_preference")
+        private String ratioPreference;     // "MAJOR", "BALANCED", "LIBERAL_ARTS"
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class AdvancedSettings {
+        @JsonProperty("tech_stack")
+        private String techStack;  // "React, Python, AWS"
+    }
+}

--- a/src/main/java/grit/guidance/domain/roadmap/dto/SearchRequest.java
+++ b/src/main/java/grit/guidance/domain/roadmap/dto/SearchRequest.java
@@ -1,0 +1,12 @@
+package grit.guidance.domain.roadmap.dto;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class SearchRequest {
+    private String query;
+}

--- a/src/main/java/grit/guidance/domain/roadmap/repository/QdrantRepository.java
+++ b/src/main/java/grit/guidance/domain/roadmap/repository/QdrantRepository.java
@@ -1,6 +1,7 @@
 package grit.guidance.domain.roadmap.repository;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.cdimascio.dotenv.Dotenv;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -19,15 +20,38 @@ public class QdrantRepository {
     private final String qdrantHost;
     private final int qdrantPort;
     private final String collectionName;
+    private final String openaiApiKey;
 
     public QdrantRepository(@Value("${spring.ai.vectorstore.qdrant.host:localhost}") String qdrantHost,
                            @Value("${spring.ai.vectorstore.qdrant.port:6333}") int qdrantPort,
-                           @Value("${spring.ai.vectorstore.qdrant.collection:test_collection}") String collectionName) {
+                           @Value("${spring.ai.vectorstore.qdrant.collection:test_collection}") String collectionName,
+                           @Value("${spring.ai.openai.api-key:}") String openaiApiKey) {
         this.restTemplate = new RestTemplate();
         this.objectMapper = new ObjectMapper();
         this.qdrantHost = qdrantHost;
         this.qdrantPort = qdrantPort;
         this.collectionName = collectionName;
+        
+        // .env 파일에서 직접 API 키 읽기
+        String envApiKey = null;
+        try {
+            Dotenv dotenv = Dotenv.configure().ignoreIfMissing().load();
+            envApiKey = dotenv.get("OPENAI_API_KEY");
+        } catch (Exception e) {
+            System.out.println("⚠️ .env 파일을 읽을 수 없습니다: " + e.getMessage());
+        }
+        
+        // Spring 설정에서 읽은 키가 있으면 사용, 없으면 .env에서 읽은 키 사용
+        this.openaiApiKey = (openaiApiKey != null && !openaiApiKey.trim().isEmpty()) ? openaiApiKey : envApiKey;
+        
+        // 디버깅용 로그
+        System.out.println("🔍 QdrantRepository 초기화:");
+        System.out.println("  - qdrantHost: " + qdrantHost);
+        System.out.println("  - qdrantPort: " + qdrantPort);
+        System.out.println("  - collectionName: " + collectionName);
+        System.out.println("  - Spring API Key: " + (openaiApiKey != null ? openaiApiKey.substring(0, Math.min(20, openaiApiKey.length())) + "..." : "null"));
+        System.out.println("  - .env API Key: " + (envApiKey != null ? envApiKey.substring(0, Math.min(20, envApiKey.length())) + "..." : "null"));
+        System.out.println("  - Final API Key: " + (this.openaiApiKey != null ? this.openaiApiKey.substring(0, Math.min(20, this.openaiApiKey.length())) + "..." : "null"));
     }
 
     /**
@@ -35,22 +59,112 @@ public class QdrantRepository {
      */
     private List<Double> generateEmbedding(String text) {
         try {
-            // 간단한 더미 벡터 생성 (실제로는 OpenAI API 호출)
-            // TODO: 실제 OpenAI API 호출로 교체
-            List<Double> vector = new ArrayList<>();
-            for (int i = 0; i < 1536; i++) {
-                vector.add(Math.random());
+            // OpenAI API 키가 없으면 더미 벡터 사용
+            if (openaiApiKey == null || openaiApiKey.trim().isEmpty()) {
+                System.out.println("⚠️ OpenAI API 키가 설정되지 않아 더미 벡터를 사용합니다.");
+                return generateDummyVector();
             }
-            return vector;
+
+            // OpenAI API 호출
+            String url = "https://api.openai.com/v1/embeddings";
+            
+            Map<String, Object> requestBody = new HashMap<>();
+            requestBody.put("input", text);
+            requestBody.put("model", "text-embedding-ada-002");
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.set("Content-Type", "application/json");
+            headers.set("Authorization", "Bearer " + openaiApiKey);
+
+            HttpEntity<Map<String, Object>> entity = new HttpEntity<>(requestBody, headers);
+            
+            ResponseEntity<Map> response = restTemplate.exchange(url, HttpMethod.POST, entity, Map.class);
+            
+            if (response.getStatusCode().is2xxSuccessful() && response.getBody() != null) {
+                Map<String, Object> responseBody = response.getBody();
+                List<Map<String, Object>> data = (List<Map<String, Object>>) responseBody.get("data");
+                if (data != null && !data.isEmpty()) {
+                    List<Double> embedding = (List<Double>) data.get(0).get("embedding");
+                    System.out.println("✅ OpenAI API로 벡터 생성 성공: " + text.substring(0, Math.min(50, text.length())) + "...");
+                    return embedding;
+                }
+            }
+            
+            System.err.println("❌ OpenAI API 응답 오류: " + response.getStatusCode());
+            return generateDummyVector();
+            
         } catch (Exception e) {
-            System.err.println("벡터 생성 실패: " + e.getMessage());
-            // 기본 벡터 반환
-            List<Double> vector = new ArrayList<>();
-            for (int i = 0; i < 1536; i++) {
-                vector.add(0.0);
-            }
-            return vector;
+            System.err.println("❌ OpenAI API 호출 실패: " + e.getMessage());
+            return generateDummyVector();
         }
+    }
+
+    /**
+     * 더미 벡터 생성 (OpenAI API 사용 불가 시)
+     */
+    private List<Double> generateDummyVector() {
+        List<Double> vector = new ArrayList<>();
+        for (int i = 0; i < 1536; i++) {
+            vector.add(Math.random());
+        }
+        return vector;
+    }
+
+    /**
+     * 문서에서 벡터화할 텍스트 생성
+     */
+    private String createEmbeddingText(Map<String, Object> document) {
+        StringBuilder text = new StringBuilder();
+
+        // 과목명
+        String courseName = (String) document.get("courseName");
+        if (courseName != null) {
+            text.append(courseName).append(" ");
+        }
+
+        // 과목 설명
+        String description = (String) document.get("description");
+        if (description != null && !description.trim().isEmpty()) {
+            text.append(description).append(" ");
+        }
+
+        // 과목 코드
+        String courseCode = (String) document.get("courseCode");
+        if (courseCode != null) {
+            text.append(courseCode).append(" ");
+        }
+
+        // 학점 정보
+        Object credits = document.get("credits");
+        if (credits != null) {
+            text.append(credits).append("학점 ");
+        }
+
+        // 개설 학년
+        Object openGrade = document.get("openGrade");
+        if (openGrade != null) {
+            text.append(openGrade).append("학년 ");
+        }
+
+        // 개설 학기
+        String openSemester = (String) document.get("openSemester");
+        if (openSemester != null) {
+            text.append(openSemester).append(" ");
+        }
+
+        // 트랙명 (트랙 요구사항인 경우)
+        String trackName = (String) document.get("trackName");
+        if (trackName != null) {
+            text.append(trackName).append(" ");
+        }
+
+        // 과목 타입 (트랙 요구사항인 경우)
+        String courseTypeDescription = (String) document.get("courseTypeDescription");
+        if (courseTypeDescription != null) {
+            text.append(courseTypeDescription).append(" ");
+        }
+
+        return text.toString().trim();
     }
 
     /**
@@ -58,11 +172,13 @@ public class QdrantRepository {
      */
     public void addCourseDocument(Map<String, Object> document) {
         try {
-            String description = (String) document.get("description");
             String id = (String) document.get("id");
             
-            // OpenAI API로 벡터 생성 (description 사용)
-            List<Double> vector = generateEmbedding(description);
+            // 벡터화할 텍스트 생성 (과목명 + 설명 + 기타 정보)
+            String text = createEmbeddingText(document);
+            
+            // OpenAI API로 벡터 생성
+            List<Double> vector = generateEmbedding(text);
             
             // Qdrant 포인트 생성 (ID를 숫자로 변환)
             int numericId = Math.abs(id.hashCode());
@@ -85,9 +201,9 @@ public class QdrantRepository {
             ResponseEntity<String> response = restTemplate.exchange(url, HttpMethod.PUT, entity, String.class);
             
             if (response.getStatusCode().is2xxSuccessful()) {
-                System.out.println("Qdrant 직접 저장 성공: " + id);
+                System.out.println("✅ Qdrant 직접 저장 성공: " + id + " - " + text.substring(0, Math.min(50, text.length())));
             } else {
-                System.err.println("Qdrant 저장 실패: " + response.getStatusCode());
+                System.err.println("❌ Qdrant 저장 실패: " + response.getStatusCode());
             }
             
         } catch (Exception e) {
@@ -149,17 +265,12 @@ public class QdrantRepository {
     }
 
     /**
-     * 유사한 과목을 검색 (기본 5개)
-     */
-    public List<Map<String, Object>> searchSimilarCourses(String query) {
-        return searchSimilarCourses(query, 5);
-    }
-
-    /**
      * 유사한 과목을 검색 (개수 지정)
      */
     public List<Map<String, Object>> searchSimilarCourses(String query, int topK) {
         try {
+            System.out.println("🔍 Qdrant 검색 시작: query='" + query + "', topK=" + topK);
+            
             // 쿼리 텍스트를 벡터로 변환
             List<Double> queryVector = generateEmbedding(query);
             
@@ -171,6 +282,8 @@ public class QdrantRepository {
             requestBody.put("limit", topK);
             requestBody.put("with_payload", true);
             
+            System.out.println("📤 Qdrant 요청 본문: " + objectMapper.writeValueAsString(requestBody));
+            
             HttpHeaders headers = new HttpHeaders();
             headers.set("Content-Type", "application/json");
             HttpEntity<Map<String, Object>> entity = new HttpEntity<>(requestBody, headers);
@@ -181,41 +294,106 @@ public class QdrantRepository {
                 Map<String, Object> responseBody = response.getBody();
                 List<Map<String, Object>> results = (List<Map<String, Object>>) responseBody.get("result");
                 
-                return results.stream()
-                        .map(result -> {
-                            Map<String, Object> payload = (Map<String, Object>) result.get("payload");
-                            Map<String, Object> searchResult = new HashMap<>(payload);
-                            searchResult.put("score", result.get("score"));
-                            return searchResult;
-                        })
-                        .toList();
+                System.out.println("✅ Qdrant 검색 성공: " + (results != null ? results.size() : 0) + "개 결과 반환");
+                
+                if (results != null) {
+                    return results.stream()
+                            .map(result -> {
+                                Map<String, Object> payload = (Map<String, Object>) result.get("payload");
+                                Map<String, Object> searchResult = new HashMap<>(payload);
+                                searchResult.put("score", result.get("score"));
+                                // text 필드 제거 (description과 중복)
+                                searchResult.remove("text");
+                                return searchResult;
+                            })
+                            .toList();
+                } else {
+                    System.out.println("⚠️ Qdrant 검색 결과가 null입니다.");
+                    return List.of();
+                }
             } else {
-                System.err.println("Qdrant 검색 실패: " + response.getStatusCode());
+                System.err.println("❌ Qdrant 검색 실패: " + response.getStatusCode());
                 return List.of();
             }
                     
         } catch (Exception e) {
-            System.err.println("Qdrant 직접 검색 실패: " + e.getMessage());
+            System.err.println("❌ Qdrant 직접 검색 실패: " + e.getMessage());
             e.printStackTrace();
             return List.of();
         }
     }
 
     /**
-     * 유사한 과목을 검색 (임계값 지정)
+     * 트랙 필터링을 포함한 유사도 검색
      */
-    public List<Map<String, Object>> searchSimilarCourses(String query, int topK, double threshold) {
-        // 임계값 검색은 기본 검색으로 대체
-        return searchSimilarCourses(query, topK);
+    public List<Map<String, Object>> searchSimilarCoursesWithFilter(String query, int topK, List<String> trackNames) {
+        try {
+            System.out.println("🔍 Qdrant 필터링 검색 시작: query='" + query + "', topK=" + topK + ", trackNames=" + trackNames);
+            
+            // 쿼리 텍스트를 벡터로 변환
+            List<Double> queryVector = generateEmbedding(query);
+            
+            // Qdrant 검색 API 호출
+            String url = String.format("http://%s:%d/collections/%s/points/search", qdrantHost, qdrantPort, collectionName);
+            
+            Map<String, Object> requestBody = new HashMap<>();
+            requestBody.put("vector", queryVector);
+            requestBody.put("limit", topK);
+            requestBody.put("with_payload", true);
+            
+            // 트랙 필터링 조건 추가
+            if (trackNames != null && !trackNames.isEmpty()) {
+                Map<String, Object> filter = new HashMap<>();
+                Map<String, Object> must = new HashMap<>();
+                Map<String, Object> key = new HashMap<>();
+                key.put("key", "tracks");
+                key.put("match", Map.of("any", trackNames));
+                must.put("must", List.of(key));
+                filter.put("must", List.of(must));
+                requestBody.put("filter", filter);
+            }
+            
+            System.out.println("📤 Qdrant 필터링 요청 본문: " + objectMapper.writeValueAsString(requestBody));
+            
+            HttpHeaders headers = new HttpHeaders();
+            headers.set("Content-Type", "application/json");
+            HttpEntity<Map<String, Object>> entity = new HttpEntity<>(requestBody, headers);
+            
+            ResponseEntity<Map> response = restTemplate.exchange(url, HttpMethod.POST, entity, Map.class);
+            
+            if (response.getStatusCode().is2xxSuccessful() && response.getBody() != null) {
+                Map<String, Object> responseBody = response.getBody();
+                List<Map<String, Object>> results = (List<Map<String, Object>>) responseBody.get("result");
+                
+                System.out.println("✅ Qdrant 필터링 검색 성공: " + (results != null ? results.size() : 0) + "개 결과 반환");
+                
+                if (results != null) {
+                    return results.stream()
+                            .map(result -> {
+                                Map<String, Object> payload = (Map<String, Object>) result.get("payload");
+                                Map<String, Object> searchResult = new HashMap<>(payload);
+                                searchResult.put("score", result.get("score"));
+                                // text 필드 제거 (description과 중복)
+                                searchResult.remove("text");
+                                return searchResult;
+                            })
+                            .toList();
+                } else {
+                    System.out.println("⚠️ Qdrant 필터링 검색 결과가 null입니다.");
+                    return List.of();
+                }
+            } else {
+                System.err.println("❌ Qdrant 필터링 검색 실패: " + response.getStatusCode());
+                return List.of();
+            }
+                    
+        } catch (Exception e) {
+            System.err.println("❌ Qdrant 필터링 검색 실패: " + e.getMessage());
+            e.printStackTrace();
+            return List.of();
+        }
     }
 
-    /**
-     * 필터를 사용한 과목 검색
-     */
-    public List<Map<String, Object>> searchCoursesWithFilter(String query, int topK, String filterExpression) {
-        // 필터 검색은 기본 검색으로 대체
-        return searchSimilarCourses(query, topK);
-    }
 
     /**
      * 특정 과목 문서 삭제 (ID 기반)

--- a/src/main/java/grit/guidance/domain/roadmap/repository/QdrantRepository.java
+++ b/src/main/java/grit/guidance/domain/roadmap/repository/QdrantRepository.java
@@ -43,7 +43,7 @@ public class QdrantRepository {
             }
             return vector;
         } catch (Exception e) {
-            System.err.println("❌ 벡터 생성 실패: " + e.getMessage());
+            System.err.println("벡터 생성 실패: " + e.getMessage());
             // 기본 벡터 반환
             List<Double> vector = new ArrayList<>();
             for (int i = 0; i < 1536; i++) {
@@ -85,13 +85,13 @@ public class QdrantRepository {
             ResponseEntity<String> response = restTemplate.exchange(url, HttpMethod.PUT, entity, String.class);
             
             if (response.getStatusCode().is2xxSuccessful()) {
-                System.out.println("✅ Qdrant 직접 저장 성공: " + id);
+                System.out.println("Qdrant 직접 저장 성공: " + id);
             } else {
-                System.err.println("❌ Qdrant 저장 실패: " + response.getStatusCode());
+                System.err.println("Qdrant 저장 실패: " + response.getStatusCode());
             }
             
         } catch (Exception e) {
-            System.err.println("❌ Qdrant 직접 저장 실패: " + e.getMessage());
+            System.err.println("Qdrant 직접 저장 실패: " + e.getMessage());
             e.printStackTrace();
         }
     }
@@ -137,13 +137,13 @@ public class QdrantRepository {
             ResponseEntity<String> response = restTemplate.exchange(url, HttpMethod.PUT, entity, String.class);
             
             if (response.getStatusCode().is2xxSuccessful()) {
-                System.out.println("✅ Qdrant 직접 일괄 저장 성공: " + documents.size() + "개 문서");
+                System.out.println("Qdrant 직접 일괄 저장 성공: " + documents.size() + "개 문서");
             } else {
-                System.err.println("❌ Qdrant 일괄 저장 실패: " + response.getStatusCode());
+                System.err.println("Qdrant 일괄 저장 실패: " + response.getStatusCode());
             }
             
         } catch (Exception e) {
-            System.err.println("❌ Qdrant 직접 일괄 저장 실패: " + e.getMessage());
+            System.err.println("Qdrant 직접 일괄 저장 실패: " + e.getMessage());
             e.printStackTrace();
         }
     }
@@ -190,12 +190,12 @@ public class QdrantRepository {
                         })
                         .toList();
             } else {
-                System.err.println("❌ Qdrant 검색 실패: " + response.getStatusCode());
+                System.err.println("Qdrant 검색 실패: " + response.getStatusCode());
                 return List.of();
             }
                     
         } catch (Exception e) {
-            System.err.println("❌ Qdrant 직접 검색 실패: " + e.getMessage());
+            System.err.println("Qdrant 직접 검색 실패: " + e.getMessage());
             e.printStackTrace();
             return List.of();
         }
@@ -234,14 +234,14 @@ public class QdrantRepository {
             ResponseEntity<String> response = restTemplate.exchange(url, HttpMethod.POST, entity, String.class);
             
             if (response.getStatusCode().is2xxSuccessful()) {
-                System.out.println("✅ Qdrant 직접 문서 삭제 성공: " + courseId);
+                System.out.println("Qdrant 직접 문서 삭제 성공: " + courseId);
                 return true;
             } else {
-                System.err.println("❌ Qdrant 문서 삭제 실패: " + response.getStatusCode());
+                System.err.println("Qdrant 문서 삭제 실패: " + response.getStatusCode());
                 return false;
             }
         } catch (Exception e) {
-            System.err.println("❌ Qdrant 직접 문서 삭제 실패: " + e.getMessage());
+            System.err.println("Qdrant 직접 문서 삭제 실패: " + e.getMessage());
             e.printStackTrace();
             return false;
         }
@@ -264,14 +264,14 @@ public class QdrantRepository {
             ResponseEntity<String> response = restTemplate.exchange(url, HttpMethod.POST, entity, String.class);
             
             if (response.getStatusCode().is2xxSuccessful()) {
-                System.out.println("✅ Qdrant 직접 " + courseIds.size() + "개 문서 삭제 성공");
+                System.out.println("Qdrant 직접 " + courseIds.size() + "개 문서 삭제 성공");
                 return true;
             } else {
-                System.err.println("❌ Qdrant 일괄 삭제 실패: " + response.getStatusCode());
+                System.err.println("Qdrant 일괄 삭제 실패: " + response.getStatusCode());
                 return false;
             }
         } catch (Exception e) {
-            System.err.println("❌ Qdrant 직접 일괄 삭제 실패: " + e.getMessage());
+            System.err.println("Qdrant 직접 일괄 삭제 실패: " + e.getMessage());
             e.printStackTrace();
             return false;
         }
@@ -294,14 +294,14 @@ public class QdrantRepository {
             ResponseEntity<String> response = restTemplate.exchange(url, HttpMethod.POST, entity, String.class);
             
             if (response.getStatusCode().is2xxSuccessful()) {
-                System.out.println("✅ Qdrant 직접 전체 삭제 성공");
+                System.out.println("Qdrant 직접 전체 삭제 성공");
                 return true;
             } else {
-                System.err.println("❌ Qdrant 전체 삭제 실패: " + response.getStatusCode());
+                System.err.println("Qdrant 전체 삭제 실패: " + response.getStatusCode());
                 return false;
             }
         } catch (Exception e) {
-            System.err.println("❌ Qdrant 직접 전체 삭제 실패: " + e.getMessage());
+            System.err.println("Qdrant 직접 전체 삭제 실패: " + e.getMessage());
             e.printStackTrace();
             return false;
         }
@@ -316,7 +316,7 @@ public class QdrantRepository {
             ResponseEntity<Map> response = restTemplate.getForEntity(url, Map.class);
             return response.getStatusCode().is2xxSuccessful();
         } catch (Exception e) {
-            System.err.println("❌ Qdrant 상태 확인 실패: " + e.getMessage());
+            System.err.println("Qdrant 상태 확인 실패: " + e.getMessage());
             return false;
         }
     }
@@ -337,7 +337,7 @@ public class QdrantRepository {
             }
             return 0L;
         } catch (Exception e) {
-            System.err.println("❌ Qdrant 문서 개수 확인 실패: " + e.getMessage());
+            System.err.println("Qdrant 문서 개수 확인 실패: " + e.getMessage());
             return -1L;
         }
     }

--- a/src/main/java/grit/guidance/domain/roadmap/service/CourseEmbeddingService.java
+++ b/src/main/java/grit/guidance/domain/roadmap/service/CourseEmbeddingService.java
@@ -1,13 +1,21 @@
 package grit.guidance.domain.roadmap.service;
 
 import grit.guidance.domain.course.entity.Course;
+import grit.guidance.domain.course.entity.TrackRequirement;
 import grit.guidance.domain.course.repository.CourseRepository;
+import grit.guidance.domain.course.repository.TrackRequirementRepository;
+import grit.guidance.domain.roadmap.dto.CourseRecommendationRequest;
 import grit.guidance.domain.roadmap.repository.QdrantRepository;
+import grit.guidance.domain.user.repository.CompletedCourseRepository;
+import grit.guidance.domain.user.repository.EnrolledCourseRepository;
+import grit.guidance.domain.user.repository.UsersRepository;
+import grit.guidance.domain.user.entity.Users;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -20,10 +28,15 @@ public class CourseEmbeddingService {
     private static final Logger log = LoggerFactory.getLogger(CourseEmbeddingService.class);
     
     private final CourseRepository courseRepository;
+    private final TrackRequirementRepository trackRequirementRepository;
     private final QdrantRepository qdrantRepository;
+    private final CompletedCourseRepository completedCourseRepository;
+    private final EnrolledCourseRepository enrolledCourseRepository;
+    private final UsersRepository usersRepository;
+    private final LlmRoadmapService llmRoadmapService;
 
     /**
-     * 모든 과목을 Qdrant에 저장
+     * 모든 과목을 Qdrant에 저장 (트랙 정보 포함)
      */
     public void embedAllCourses() {
         try {
@@ -38,18 +51,18 @@ public class CourseEmbeddingService {
                 return;
             }
 
-            // 2. Map으로 변환
-            List<Map<String, Object>> documents = courses.stream()
-                    .map(this::createCourseDocument)
+            // 2. 과목을 Map으로 변환 (트랙 정보 포함)
+            List<Map<String, Object>> courseDocuments = courses.stream()
+                    .map(this::createCourseDocumentWithTracks)
                     .collect(Collectors.toList());
 
             // 3. Qdrant에 저장
-            qdrantRepository.addCourseDocuments(documents);
-            log.info("{}개의 과목을 Qdrant에 성공적으로 저장했습니다.", documents.size());
+            qdrantRepository.addCourseDocuments(courseDocuments);
+            log.info("{}개의 과목을 Qdrant에 성공적으로 저장했습니다.", courseDocuments.size());
 
         } catch (Exception e) {
             log.error("과목 데이터 벡터화 및 저장 실패", e);
-            throw new RuntimeException("과목 데이터 저장에 실패했습니다.", e);
+            throw new RuntimeException("데이터 저장에 실패했습니다.", e);
         }
     }
 
@@ -60,7 +73,7 @@ public class CourseEmbeddingService {
         try {
             log.info("과목 벡터화 및 저장: {} - {}", course.getCourseCode(), course.getCourseName());
 
-            Map<String, Object> document = createCourseDocument(course);
+            Map<String, Object> document = createCourseDocumentWithTracks(course);
             qdrantRepository.addCourseDocument(document);
 
             log.info("과목 저장 완료: {} - {}", course.getCourseCode(), course.getCourseName());
@@ -72,25 +85,26 @@ public class CourseEmbeddingService {
     }
 
     /**
-     * Course 엔티티를 Map으로 변환
+     * Course 엔티티를 Map으로 변환 (트랙 정보 포함)
      */
-    private Map<String, Object> createCourseDocument(Course course) {
-        // 1. 벡터화할 텍스트 생성
-        String text = createEmbeddingText(course);
+    private Map<String, Object> createCourseDocumentWithTracks(Course course) {
+        // 1. 벡터화할 텍스트 생성 (트랙 정보 포함)
+        String text = createEmbeddingTextWithTracks(course);
 
-        // 2. 메타데이터 생성
-        Map<String, Object> metadata = createCourseMetadata(course);
+        // 2. 메타데이터 생성 (트랙 정보 포함)
+        Map<String, Object> metadata = createCourseMetadataWithTracks(course);
 
-        // 3. Map에 ID만 추가 (text 필드는 제거)
+        // 3. Map에 ID와 텍스트 추가
         metadata.put("id", "course_" + course.getId());
+        metadata.put("text", text);
 
         return metadata;
     }
 
     /**
-     * 벡터화할 텍스트 생성
+     * 벡터화할 텍스트 생성 (트랙 정보 포함)
      */
-    private String createEmbeddingText(Course course) {
+    private String createEmbeddingTextWithTracks(Course course) {
         StringBuilder text = new StringBuilder();
 
         // 과목명
@@ -111,13 +125,20 @@ public class CourseEmbeddingService {
         text.append(course.getOpenGrade()).append("학년 ");
         text.append(course.getOpenSemester().name()).append(" ");
 
+        // 트랙 정보 추가 (TrackRequirement를 통해)
+        List<TrackRequirement> trackRequirements = trackRequirementRepository.findByCourseId(course.getId());
+        for (TrackRequirement tr : trackRequirements) {
+            text.append(tr.getTrack().getTrackName()).append(" ");
+            text.append(tr.getCourseType().getDescription()).append(" ");
+        }
+
         return text.toString().trim();
     }
 
     /**
-     * 과목 메타데이터 생성
+     * 과목 메타데이터 생성 (트랙 정보 포함)
      */
-    private Map<String, Object> createCourseMetadata(Course course) {
+    private Map<String, Object> createCourseMetadataWithTracks(Course course) {
         Map<String, Object> metadata = new HashMap<>();
         metadata.put("courseId", course.getId());
         metadata.put("courseCode", course.getCourseCode());
@@ -127,8 +148,19 @@ public class CourseEmbeddingService {
         metadata.put("openGrade", course.getOpenGrade());
         metadata.put("openSemester", course.getOpenSemester().name());
         metadata.put("type", "course");
+
+        // 트랙 정보 추가 (TrackRequirement를 통해)
+        List<TrackRequirement> trackRequirements = trackRequirementRepository.findByCourseId(course.getId());
+        
+        // 트랙 목록만 저장
+        List<String> tracks = trackRequirements.stream()
+                .map(tr -> tr.getTrack().getTrackName())
+                .collect(Collectors.toList());
+        metadata.put("tracks", tracks);
+
         return metadata;
     }
+
 
     /**
      * Qdrant에서 과목 검색 (테스트용)
@@ -144,6 +176,289 @@ public class CourseEmbeddingService {
     }
 
     /**
+     * 사용자 요청 기반 과목 검색 (2단계: 취향 저격 과목)
+     */
+    public List<Map<String, Object>> searchCoursesByPreference(String userQuery, int topK) {
+        try {
+            log.info("🔍 CourseEmbeddingService 검색 시작: query='{}', topK={}", userQuery, topK);
+            
+            // Qdrant에서 유사도 검색
+            List<Map<String, Object>> searchResults = qdrantRepository.searchSimilarCourses(userQuery, topK);
+            
+            log.info("CourseEmbeddingService 검색 완료: {}개의 과목을 찾았습니다.", searchResults.size());
+            return searchResults;
+            
+        } catch (Exception e) {
+            log.error("CourseEmbeddingService 과목 검색 실패: {}", userQuery, e);
+            throw new RuntimeException("과목 검색에 실패했습니다.", e);
+        }
+    }
+
+    /**
+     * 1단계: 필수 과목 목록 확보 (규칙 기반 필터링)
+     * 학생의 트랙에서 전공필수(MANDATORY)와 전공기초(FOUNDATION) 과목 중 아직 이수하지 않은 과목들을 반환
+     */
+    public List<Map<String, Object>> getMandatoryCourses(List<Long> trackIds, String studentId) {
+        try {
+            log.info("📋 1단계: 필수 과목 목록 확보 시작 - trackIds={}, studentId={}", trackIds, studentId);
+
+            // 1. 학번으로 사용자 찾기
+            Users user = usersRepository.findByStudentId(studentId)
+                    .orElseThrow(() -> new RuntimeException("학번 " + studentId + "에 해당하는 사용자를 찾을 수 없습니다."));
+
+            // 2. 사용자의 트랙에서 전공필수/전공기초 과목 조회
+            List<TrackRequirement> trackRequirements = trackRequirementRepository.findByTrackIdsAndCourseType(trackIds);
+            
+            // 3. 이미 이수한 과목과 수강중인 과목 ID 목록 조회
+            List<Long> completedCourseIds = completedCourseRepository.findCourseIdsByUserId(user.getId());
+            List<Long> enrolledCourseIds = enrolledCourseRepository.findCourseIdsByUserId(user.getId());
+            
+            // 4. 이수/수강중인 과목 제외
+            List<Map<String, Object>> mandatoryCourses = new ArrayList<>();
+            
+            for (TrackRequirement requirement : trackRequirements) {
+                Course course = requirement.getCourse();
+                Long courseId = course.getId();
+                
+                // 이미 이수했거나 수강중인 과목은 제외
+                if (completedCourseIds.contains(courseId) || enrolledCourseIds.contains(courseId)) {
+                    continue;
+                }
+                
+                // 필수 과목 정보 생성
+                Map<String, Object> courseInfo = new HashMap<>();
+                courseInfo.put("courseId", courseId);
+                courseInfo.put("courseName", course.getCourseName());
+                courseInfo.put("courseCode", course.getCourseCode());
+                courseInfo.put("credits", course.getCredits());
+                courseInfo.put("openGrade", course.getOpenGrade());
+                courseInfo.put("openSemester", course.getOpenSemester());
+                courseInfo.put("description", course.getDescription());
+                courseInfo.put("courseType", requirement.getCourseType()); // "MANDATORY" 또는 "FOUNDATION"
+                courseInfo.put("trackName", requirement.getTrack().getTrackName());
+                
+                mandatoryCourses.add(courseInfo);
+            }
+
+            log.info("✅ 1단계: 필수 과목 목록 확보 완료 - {}개 과목", mandatoryCourses.size());
+            return mandatoryCourses;
+
+        } catch (Exception e) {
+            log.error("❌ 1단계: 필수 과목 목록 확보 실패 - trackIds={}, studentId={}", trackIds, studentId, e);
+            throw new RuntimeException("필수 과목 목록 확보에 실패했습니다.", e);
+        }
+    }
+
+    /**
+     * 2단계: 벡터 DB 검색 목록 확보 (유사도 검색)
+     * 사용자의 트랙과 학습 스타일을 고려하여 Qdrant에서 유사도 검색
+     */
+    public List<Map<String, Object>> getRecommendedCourses(List<Long> trackIds, String studentId,
+                                                          CourseRecommendationRequest.LearningStyle learningStyle,
+                                                          CourseRecommendationRequest.AdvancedSettings advancedSettings) {
+        try {
+            log.info("🔍 2단계: 벡터 DB 검색 시작 - trackIds={}, studentId={}, learningStyle={}, advancedSettings={}", 
+                    trackIds, studentId, learningStyle, advancedSettings);
+
+            // 1. 학번으로 사용자 찾기
+            Users user = usersRepository.findByStudentId(studentId)
+                    .orElseThrow(() -> new RuntimeException("학번 " + studentId + "에 해당하는 사용자를 찾을 수 없습니다."));
+
+            // 2. 이미 이수한 과목과 수강중인 과목 ID 목록 조회
+            List<Long> completedCourseIds = completedCourseRepository.findCourseIdsByUserId(user.getId());
+            List<Long> enrolledCourseIds = enrolledCourseRepository.findCourseIdsByUserId(user.getId());
+            
+            // 3. 검색 쿼리 생성 (tech_stack 우선, 없으면 기본 쿼리)
+            String searchQuery;
+            if (advancedSettings != null && advancedSettings.getTechStack() != null && !advancedSettings.getTechStack().trim().isEmpty()) {
+                searchQuery = advancedSettings.getTechStack();
+                log.info("🔍 Tech Stack 기반 검색: {}", searchQuery);
+            } else {
+                searchQuery = "프로그래밍 개발"; // 기본 검색 쿼리
+                log.info("🔍 기본 검색 쿼리 사용: {}", searchQuery);
+            }
+            
+            // 4. 트랙 이름 목록 조회 (Qdrant 필터링용)
+            List<String> trackNames = getTrackNamesByIds(trackIds);
+            log.info("🔍 트랙 필터링: {}", trackNames);
+            
+            // 5. Qdrant에서 트랙 필터링된 유사도 검색
+            List<Map<String, Object>> searchResults = qdrantRepository.searchSimilarCoursesWithFilter(
+                    searchQuery, 30, trackNames);
+            log.info("🔍 Qdrant 검색 결과: {}개", searchResults.size());
+            
+            // 6. 이수/수강중인 과목 제외
+            List<Map<String, Object>> recommendedCourses = new ArrayList<>();
+            
+            for (Map<String, Object> course : searchResults) {
+                // Qdrant 결과에서 courseId 추출 (문자열로 저장되어 있을 수 있음)
+                Object courseIdObj = course.get("courseId");
+                Long courseId = null;
+                
+                if (courseIdObj instanceof Long) {
+                    courseId = (Long) courseIdObj;
+                } else if (courseIdObj instanceof String) {
+                    try {
+                        courseId = Long.parseLong((String) courseIdObj);
+                    } catch (NumberFormatException e) {
+                        log.warn("⚠️ 잘못된 courseId 형식: {}", courseIdObj);
+                        continue;
+                    }
+                } else if (courseIdObj instanceof Integer) {
+                    courseId = ((Integer) courseIdObj).longValue();
+                }
+                
+                if (courseId == null) {
+                    continue;
+                }
+                
+                // 이미 이수했거나 수강중인 과목은 제외
+                if (completedCourseIds.contains(courseId) || enrolledCourseIds.contains(courseId)) {
+                    continue;
+                }
+                
+                recommendedCourses.add(course);
+            }
+
+            log.info("✅ 2단계: 벡터 DB 검색 완료 - {}개 과목 (트랙 필터링 후)", recommendedCourses.size());
+            return recommendedCourses;
+
+        } catch (Exception e) {
+            log.error("❌ 2단계: 벡터 DB 검색 실패 - trackIds={}, studentId={}, learningStyle={}", trackIds, studentId, learningStyle, e);
+            throw new RuntimeException("벡터 DB 검색에 실패했습니다.", e);
+        }
+    }
+    
+    /**
+     * 트랙 ID 목록으로 트랙 이름 목록 조회
+     */
+    private List<String> getTrackNamesByIds(List<Long> trackIds) {
+        try {
+            List<TrackRequirement> requirements = trackRequirementRepository.findByTrackIdsAndCourseType(trackIds);
+            return requirements.stream()
+                    .map(req -> req.getTrack().getTrackName())
+                    .distinct()
+                    .collect(Collectors.toList());
+        } catch (Exception e) {
+            log.error("❌ 트랙 이름 조회 실패 - trackIds: {}", trackIds, e);
+            return new ArrayList<>();
+        }
+    }
+    
+    /**
+     * 주어진 트랙들에 속하는 모든 과목 ID 목록 조회
+     */
+    private List<Long> getCourseIdsByTracks(List<Long> trackIds) {
+        try {
+            List<TrackRequirement> requirements = trackRequirementRepository.findByTrackIdsAndCourseType(trackIds);
+            return requirements.stream()
+                    .map(req -> req.getCourse().getId())
+                    .distinct()
+                    .collect(Collectors.toList());
+        } catch (Exception e) {
+            log.error("❌ 트랙별 과목 조회 실패 - trackIds: {}", trackIds, e);
+            return new ArrayList<>();
+        }
+    }
+    
+    /**
+     * 사용자의 현재 학기 상태 계산
+     */
+    private Map<String, Object> calculateUserSemester(String studentId) {
+        try {
+            // 1. 학번으로 사용자 찾기
+            Users user = usersRepository.findByStudentId(studentId)
+                    .orElseThrow(() -> new RuntimeException("학번 " + studentId + "에 해당하는 사용자를 찾을 수 없습니다."));
+
+            // 2. 이수한 과목 중 가장 최신 학년/학기 찾기
+            List<grit.guidance.domain.user.entity.CompletedCourse> completedCourses = 
+                    completedCourseRepository.findByUsers(user);
+            
+            int latestYear = 0;
+            String latestSemester = "FIRST";
+            
+            if (!completedCourses.isEmpty()) {
+                for (grit.guidance.domain.user.entity.CompletedCourse completed : completedCourses) {
+                    if (completed.getCompletedYear() > latestYear) {
+                        latestYear = completed.getCompletedYear();
+                        latestSemester = completed.getCompletedSemester().toString();
+                    } else if (completed.getCompletedYear() == latestYear) {
+                        // 같은 년도면 학기 비교 (SECOND > FIRST)
+                        if ("SECOND".equals(completed.getCompletedSemester().toString()) && 
+                            "FIRST".equals(latestSemester)) {
+                            latestSemester = "SECOND";
+                        }
+                    }
+                }
+            }
+            
+            // 3. 현재 수강중인 과목이 있는지 확인
+            List<grit.guidance.domain.user.entity.EnrolledCourse> enrolledCourses = 
+                    enrolledCourseRepository.findByUser(user);
+            boolean hasCurrentEnrollment = !enrolledCourses.isEmpty();
+            
+            // 4. 다음 학기 계산
+            int nextYear;
+            String nextSemester;
+            
+            if (hasCurrentEnrollment) {
+                // 현재 수강중인 과목이 있으면, 현재 수강중인 학기의 다음 학기
+                // 최신 이수가 3-1이고 현재 수강중이면 → 현재는 3-2 → 다음은 4-1
+                if ("FIRST".equals(latestSemester)) {
+                    // 최신 이수가 1학기면, 현재는 2학기 → 다음은 다음년도 1학기
+                    nextYear = latestYear + 1;
+                    nextSemester = "FIRST";
+                } else { // SECOND
+                    // 최신 이수가 2학기면, 현재는 다음년도 1학기 → 다음은 다음년도 2학기
+                    nextYear = latestYear + 1;
+                    nextSemester = "SECOND";
+                }
+            } else {
+                // 현재 수강중인 과목이 없으면 +1학기
+                if ("FIRST".equals(latestSemester)) {
+                    nextYear = latestYear;
+                    nextSemester = "SECOND";
+                } else { // SECOND
+                    nextYear = latestYear + 1;
+                    nextSemester = "FIRST";
+                }
+            }
+            
+            Map<String, Object> semesterInfo = new HashMap<>();
+            semesterInfo.put("latestCompletedYear", latestYear);
+            semesterInfo.put("latestCompletedSemester", latestSemester);
+            semesterInfo.put("hasCurrentEnrollment", hasCurrentEnrollment);
+            semesterInfo.put("nextYear", nextYear);
+            semesterInfo.put("nextSemester", nextSemester);
+            semesterInfo.put("recommendationStartYear", nextYear);
+            semesterInfo.put("recommendationStartSemester", nextSemester);
+            
+            log.info("📅 학기 계산 완료 - 최신이수: {}{}, 현재수강: {}, 추천시작: {}{}", 
+                    latestYear, latestSemester, hasCurrentEnrollment, nextYear, nextSemester);
+            
+            return semesterInfo;
+            
+        } catch (Exception e) {
+            log.error("❌ 사용자 학기 계산 실패 - studentId: {}", studentId, e);
+            throw new RuntimeException("사용자 학기 계산에 실패했습니다.", e);
+        }
+    }
+    
+    /**
+     * 특정 과목이 주어진 트랙들에 속하는지 확인
+     */
+    private boolean isCourseInTracks(Long courseId, List<Long> trackIds) {
+        try {
+            List<TrackRequirement> requirements = trackRequirementRepository.findByCourseId(courseId);
+            return requirements.stream()
+                    .anyMatch(req -> trackIds.contains(req.getTrack().getId()));
+        } catch (Exception e) {
+            log.warn("⚠️ 트랙 확인 실패 - courseId: {}, trackIds: {}", courseId, trackIds, e);
+            return false;
+        }
+    }
+
+    /**
      * Qdrant 상태 확인
      */
     public boolean isQdrantHealthy() {
@@ -155,5 +470,54 @@ public class CourseEmbeddingService {
      */
     public long getStoredCourseCount() {
         return qdrantRepository.getDocumentCount();
+    }
+
+    /**
+     * 통합 로드맵 추천 (1단계 + 2단계 + LLM)
+     */
+    public Map<String, Object> getIntegratedRoadmapRecommendation(
+            List<Long> trackIds, 
+            String studentId,
+            CourseRecommendationRequest.LearningStyle learningStyle,
+            CourseRecommendationRequest.AdvancedSettings advancedSettings) {
+        
+        try {
+            log.info("🎯 통합 로드맵 추천 시작 - trackIds={}, studentId={}", trackIds, studentId);
+
+            // 0단계: 사용자 학기 상태 파악
+            Map<String, Object> semesterInfo = calculateUserSemester(studentId);
+            log.info("📅 사용자 학기 정보: {}", semesterInfo);
+            
+            // 1단계: 필수 과목 목록 확보 (규칙 기반 필터링)
+            List<Map<String, Object>> mandatoryCourses = getMandatoryCourses(trackIds, studentId);
+            log.info("📋 1단계 완료: 필수 과목 {}개", mandatoryCourses.size());
+            
+            // 2단계: 벡터 DB 검색 목록 확보 (유사도 검색)
+            List<Map<String, Object>> recommendedCourses = getRecommendedCourses(
+                    trackIds, studentId, learningStyle, advancedSettings);
+            log.info("🔍 2단계 완료: 추천 과목 {}개", recommendedCourses.size());
+            
+            // 3단계: LLM에게 로드맵 추천 요청 (학기 정보 포함)
+            String techStack = (advancedSettings != null && advancedSettings.getTechStack() != null) 
+                    ? advancedSettings.getTechStack() : "";
+            
+            Map<String, Object> llmResponse = llmRoadmapService.generateRoadmapRecommendation(
+                    studentId, trackIds, mandatoryCourses, recommendedCourses, techStack, semesterInfo);
+            
+            // 4단계: 최종 응답 구성 (LLM 추천 결과만 반환)
+            Map<String, Object> response = new HashMap<>();
+            response.put("studentId", studentId);
+            response.put("trackIds", trackIds);
+            response.put("semesterInfo", semesterInfo);
+            response.put("roadMap", llmResponse.get("roadMap"));
+            response.put("status", "success");
+            
+            log.info("✅ 통합 로드맵 추천 완료");
+            return response;
+
+        } catch (Exception e) {
+            log.error("❌ 통합 로드맵 추천 실패 - trackIds={}, studentId={}", trackIds, studentId, e);
+            throw new RuntimeException("통합 로드맵 추천에 실패했습니다.", e);
+        }
     }
 }

--- a/src/main/java/grit/guidance/domain/roadmap/service/LlmRoadmapService.java
+++ b/src/main/java/grit/guidance/domain/roadmap/service/LlmRoadmapService.java
@@ -1,0 +1,305 @@
+package grit.guidance.domain.roadmap.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class LlmRoadmapService {
+
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+
+    @Value("${openai.api.key}")
+    private String openaiApiKey;
+
+    @Value("${openai.api.url}")
+    private String openaiApiUrl;
+
+    /**
+     * LLM에게 로드맵 추천 요청
+     */
+    public Map<String, Object> generateRoadmapRecommendation(
+            String studentId,
+            List<Long> trackIds,
+            List<Map<String, Object>> mandatoryCourses,
+            List<Map<String, Object>> recommendedCourses,
+            String techStack,
+            Map<String, Object> semesterInfo) {
+        
+        try {
+            log.info("🤖 LLM 로드맵 추천 요청 시작 - studentId: {}, trackIds: {}, mandatory: {}개, recommended: {}개", 
+                    studentId, trackIds, mandatoryCourses.size(), recommendedCourses.size());
+
+            // 프롬프트 생성 (학기 정보 포함)
+            String prompt = buildPrompt(mandatoryCourses, recommendedCourses, techStack, semesterInfo);
+            
+            // OpenAI API 호출
+            Map<String, Object> response = callOpenAI(prompt);
+            
+            log.info("LLM 로드맵 추천 완료");
+            return response;
+
+        } catch (Exception e) {
+            log.error("LLM 로드맵 추천 실패", e);
+            throw new RuntimeException("로드맵 추천 생성에 실패했습니다.", e);
+        }
+    }
+
+    /**
+     * 프롬프트 생성
+     */
+    private String buildPrompt(List<Map<String, Object>> mandatoryCourses, 
+                              List<Map<String, Object>> recommendedCourses, 
+                              String techStack,
+                              Map<String, Object> semesterInfo) {
+        
+        StringBuilder prompt = new StringBuilder();
+        
+        prompt.append("당신은 한성대학교 컴퓨터공학부 학생들을 위한 최고의 학업 로드맵 설계 AI입니다. ");
+        prompt.append("당신의 임무는 주어진 학생 정보와 추천 과목 목록, 그리고 절대 규칙을 바탕으로, ");
+        prompt.append("학생의 성공적인 미래를 위한 최적의 학기별 수강 계획을 짜주는 것입니다.\n\n");
+        
+        // 학생 학기 정보 추가
+        if (semesterInfo != null) {
+            int latestYear = (Integer) semesterInfo.get("latestCompletedYear");
+            String latestSemester = (String) semesterInfo.get("latestCompletedSemester");
+            boolean hasCurrentEnrollment = (Boolean) semesterInfo.get("hasCurrentEnrollment");
+            int nextYear = (Integer) semesterInfo.get("nextYear");
+            String nextSemester = (String) semesterInfo.get("nextSemester");
+            
+            prompt.append("📅 **학생 학기 정보:**\n");
+            prompt.append(String.format("- 최신 이수 학기: %d학년 %s학기\n", latestYear, latestSemester));
+            prompt.append(String.format("- 현재 수강중: %s\n", hasCurrentEnrollment ? "예" : "아니오"));
+            prompt.append(String.format("- 추천 시작 학기: %d학년 %s학기부터\n\n", nextYear, nextSemester));
+        }
+        
+        prompt.append("아래 목록의 과목들을 활용하여 로드맵을 구성하세요. ");
+        prompt.append("목록은 '필수 과목'과 '추천 과목'으로 나뉩니다.\n\n");
+        
+        // 1. 필수 과목 목록
+        prompt.append("1. 필수 과목 목록 (반드시 로드맵에 포함되어야 함)\n");
+        if (mandatoryCourses.isEmpty()) {
+            prompt.append("없음\n");
+        } else {
+            for (Map<String, Object> course : mandatoryCourses) {
+                prompt.append(String.format("- %s (%s): %s - %s\n", 
+                    course.get("courseName") != null ? course.get("courseName") : "N/A", 
+                    course.get("courseCode") != null ? course.get("courseCode") : "N/A",
+                    course.get("courseType") != null ? course.get("courseType") : "N/A",
+                    course.get("description") != null ? course.get("description") : "N/A"));
+            }
+        }
+        
+        prompt.append("\n");
+        
+        // 2. 추천 과목 목록
+        prompt.append("2. 추천 과목 목록 (학생의 선호도에 따라 선택적으로 포함)\n");
+        if (techStack != null && !techStack.trim().isEmpty()) {
+            prompt.append(String.format("학생의 관심 기술 스택: %s\n", techStack));
+        }
+        
+        if (recommendedCourses.isEmpty()) {
+            prompt.append("없음\n");
+        } else {
+            for (Map<String, Object> course : recommendedCourses) {
+                // score 값 안전하게 처리
+                Object scoreObj = course.get("score");
+                String scoreStr = "N/A";
+                if (scoreObj instanceof Number) {
+                    scoreStr = String.format("%.3f", ((Number) scoreObj).doubleValue());
+                } else if (scoreObj != null) {
+                    scoreStr = scoreObj.toString();
+                }
+                
+                prompt.append(String.format("- %s (%s): %s - %s (유사도: %s)\n", 
+                    course.get("courseName") != null ? course.get("courseName") : "N/A", 
+                    course.get("courseCode") != null ? course.get("courseCode") : "N/A",
+                    course.get("description") != null ? course.get("description") : "N/A",
+                    course.get("tracks") != null ? course.get("tracks") : "N/A",
+                    scoreStr));
+            }
+        }
+        
+        prompt.append("\n");
+        
+        // 3. JSON 형식 요구사항
+        prompt.append("결과는 반드시 아래와 같은 JSON 형식으로만 응답해야 합니다. ");
+        prompt.append("roadMap 배열 안에는 학기별로 추천 과목을 그룹화하고, ");
+        prompt.append("각 과목에는 추천 이유(recommendDescription)를 반드시 포함해야 합니다.\n");
+        prompt.append("**중요: 추천 시작 학기부터 순차적으로 로드맵을 구성하세요.**\n\n");
+        
+        prompt.append("{\n");
+        prompt.append("  \"roadMap\": [\n");
+        prompt.append("    {\n");
+        prompt.append("      \"recommendYear\": 4,\n");
+        prompt.append("      \"recommendSemester\": \"SECOND\",\n");
+        prompt.append("      \"courses\": [\n");
+        prompt.append("        {\n");
+        prompt.append("          \"courseCode\": \"V021009\",\n");
+        prompt.append("          \"courseName\": \"모바일시스템응용프로젝트\",\n");
+        prompt.append("          \"recommendDescription\": \"학생의 제2트랙 전공필수 과목이며, 4학년 2학기 설계 과목으로 필수적입니다.\"\n");
+        prompt.append("        },\n");
+        prompt.append("        {\n");
+        prompt.append("          \"courseCode\": \"V024009\",\n");
+        prompt.append("          \"courseName\": \"클라우드 컴퓨팅\",\n");
+        prompt.append("          \"recommendDescription\": \"학생의 제1트랙 전공필수이며, 관심 기술 스택인 AWS와 직접적으로 연관된 핵심 과목입니다.\"\n");
+        prompt.append("        }\n");
+        prompt.append("      ]\n");
+        prompt.append("    }\n");
+        prompt.append("  ]\n");
+        prompt.append("}\n");
+        
+        return prompt.toString();
+    }
+
+    /**
+     * OpenAI API 호출
+     */
+    private Map<String, Object> callOpenAI(String prompt) throws Exception {
+        String url = openaiApiUrl + "/v1/chat/completions";
+        
+        Map<String, Object> requestBody = new HashMap<>();
+        requestBody.put("model", "gpt-4o-mini");
+        requestBody.put("messages", List.of(
+            Map.of("role", "user", "content", prompt)
+        ));
+        requestBody.put("temperature", 0.7);
+        requestBody.put("max_tokens", 2000);
+        
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Content-Type", "application/json");
+        headers.set("Authorization", "Bearer " + openaiApiKey);
+        
+        HttpEntity<Map<String, Object>> entity = new HttpEntity<>(requestBody, headers);
+        
+        log.info("📤 OpenAI API 호출 시작");
+        ResponseEntity<Map> response = restTemplate.exchange(url, HttpMethod.POST, entity, Map.class);
+        
+        if (response.getStatusCode().is2xxSuccessful() && response.getBody() != null) {
+            Map<String, Object> responseBody = response.getBody();
+            List<Map<String, Object>> choices = (List<Map<String, Object>>) responseBody.get("choices");
+            
+            if (choices != null && !choices.isEmpty()) {
+                Map<String, Object> choice = choices.get(0);
+                Map<String, Object> message = (Map<String, Object>) choice.get("message");
+                String content = (String) message.get("content");
+                
+                log.info("OpenAI API 응답 성공");
+                log.info("LLM 응답 내용: {}", content);
+                
+                // JSON 추출 (마크다운 코드 블록에서 JSON 부분만 추출)
+                String jsonContent = extractJsonFromContent(content);
+                log.info("추출된 JSON: {}", jsonContent);
+                
+                // JSON 파싱
+                return objectMapper.readValue(jsonContent, Map.class);
+            }
+        }
+        
+        throw new RuntimeException("OpenAI API 호출 실패: " + response.getStatusCode());
+    }
+
+    /**
+     * LLM 응답에서 JSON 부분만 추출
+     */
+    private String extractJsonFromContent(String content) {
+        if (content == null || content.trim().isEmpty()) {
+            throw new RuntimeException("LLM 응답이 비어있습니다.");
+        }
+
+        // 마크다운 코드 블록에서 JSON 추출
+        String[] lines = content.split("\n");
+        StringBuilder jsonBuilder = new StringBuilder();
+        boolean inJsonBlock = false;
+        int braceCount = 0;
+        boolean foundFirstBrace = false;
+
+        for (String line : lines) {
+            String trimmedLine = line.trim();
+            
+            // JSON 블록 시작 감지 (```json 또는 ```)
+            if (trimmedLine.startsWith("```json") || trimmedLine.startsWith("```")) {
+                inJsonBlock = true;
+                continue;
+            }
+            
+            // JSON 블록 종료 감지
+            if (inJsonBlock && trimmedLine.equals("```")) {
+                break;
+            }
+            
+            // JSON 블록 내부에서 JSON 추출
+            if (inJsonBlock) {
+                // 첫 번째 { 찾기
+                if (!foundFirstBrace && trimmedLine.contains("{")) {
+                    foundFirstBrace = true;
+                }
+                
+                if (foundFirstBrace) {
+                    jsonBuilder.append(line).append("\n");
+                    
+                    // 중괄호 카운팅으로 JSON 완성도 확인
+                    for (char c : line.toCharArray()) {
+                        if (c == '{') braceCount++;
+                        if (c == '}') braceCount--;
+                    }
+                    
+                    // JSON이 완성되면 중단
+                    if (braceCount == 0 && foundFirstBrace) {
+                        break;
+                    }
+                }
+            }
+        }
+
+        String jsonContent = jsonBuilder.toString().trim();
+        
+        if (jsonContent.isEmpty()) {
+            // 마크다운 코드 블록이 없는 경우, 전체 내용에서 JSON 추출 시도
+            jsonContent = extractJsonFromPlainText(content);
+        }
+        
+        if (jsonContent.isEmpty()) {
+            throw new RuntimeException("LLM 응답에서 유효한 JSON을 찾을 수 없습니다. 응답: " + content);
+        }
+        
+        return jsonContent;
+    }
+
+    /**
+     * 일반 텍스트에서 JSON 추출
+     */
+    private String extractJsonFromPlainText(String content) {
+        int startIndex = content.indexOf('{');
+        if (startIndex == -1) {
+            return "";
+        }
+        
+        int braceCount = 0;
+        int endIndex = startIndex;
+        
+        for (int i = startIndex; i < content.length(); i++) {
+            char c = content.charAt(i);
+            if (c == '{') braceCount++;
+            if (c == '}') braceCount--;
+            
+            if (braceCount == 0) {
+                endIndex = i + 1;
+                break;
+            }
+        }
+        
+        return content.substring(startIndex, endIndex);
+    }
+}

--- a/src/main/java/grit/guidance/domain/user/repository/CompletedCourseRepository.java
+++ b/src/main/java/grit/guidance/domain/user/repository/CompletedCourseRepository.java
@@ -24,5 +24,9 @@ public interface CompletedCourseRepository extends JpaRepository<CompletedCourse
     // 중복 체크: 사용자, 과목, 연도, 학기가 모두 같은 완료 과목이 있는지 확인
     boolean existsByUsersAndCourseAndCompletedYearAndCompletedSemester(
         Users user, Course course, int completedYear, Semester completedSemester);
+    
+    // 사용자 ID로 이수한 과목 ID 목록 조회
+    @Query("SELECT cc.course.id FROM CompletedCourse cc WHERE cc.users.id = :userId")
+    List<Long> findCourseIdsByUserId(@Param("userId") Long userId);
 }
 

--- a/src/main/java/grit/guidance/domain/user/repository/EnrolledCourseRepository.java
+++ b/src/main/java/grit/guidance/domain/user/repository/EnrolledCourseRepository.java
@@ -3,9 +3,20 @@ package grit.guidance.domain.user.repository;
 import grit.guidance.domain.user.entity.EnrolledCourse;
 import grit.guidance.domain.user.entity.Users;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface EnrolledCourseRepository extends JpaRepository<EnrolledCourse, Long> {
     void deleteByUser(Users user);
+    
+    // 사용자로 수강중인 과목 목록 조회
+    List<EnrolledCourse> findByUser(Users user);
+    
+    // 사용자 ID로 수강중인 과목 ID 목록 조회
+    @Query("SELECT ec.course.id FROM EnrolledCourse ec WHERE ec.user.id = :userId")
+    List<Long> findCourseIdsByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/grit/guidance/global/config/SecurityConfig.java
+++ b/src/main/java/grit/guidance/global/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package grit.guidance.global.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.cors.CorsConfiguration;
@@ -11,6 +12,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import java.util.Arrays;
 
 @Configuration
+@Profile("!test")
 public class SecurityConfig {
 
     @Bean

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,6 +3,16 @@ spring:
     name: session
   profiles:
     active: ${SPRING_PROFILES_ACTIVE:dev}
+  
+  ai:
+    openai:
+      api-key: ${OPENAI_API_KEY:}
+
+# OpenAI API 설정
+openai:
+  api:
+    key: ${OPENAI_API_KEY:}
+    url: ${OPENAI_API_URL:https://api.openai.com}
 
   jackson:
     property-naming-strategy: SNAKE_CASE

--- a/src/test/java/grit/guidance/domain/roadmap/service/CourseEmbeddingServiceTest.java
+++ b/src/test/java/grit/guidance/domain/roadmap/service/CourseEmbeddingServiceTest.java
@@ -1,0 +1,191 @@
+package grit.guidance.domain.roadmap.service;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+import java.util.Map;
+
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.NONE,
+    properties = {
+        "spring.profiles.active=test",
+        "spring.datasource.driver-class-name=org.h2.Driver",
+        "spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
+        "spring.jpa.hibernate.ddl-auto=create-drop",
+        "spring.jpa.show-sql=false",
+        "spring.jpa.database-platform=org.hibernate.dialect.H2Dialect",
+        "spring.autoconfigure.exclude[0]=org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration",
+        "spring.autoconfigure.exclude[1]=org.springframework.boot.autoconfigure.security.oauth2.client.servlet.OAuth2ClientAutoConfiguration",
+        "spring.autoconfigure.exclude[2]=org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration",
+        "spring.autoconfigure.exclude[3]=org.springframework.ai.autoconfigure.openai.OpenAiAutoConfiguration",
+        "spring.autoconfigure.exclude[4]=org.springframework.ai.autoconfigure.chat.client.ChatClientAutoConfiguration",
+        "spring.autoconfigure.exclude[5]=org.springframework.ai.autoconfigure.chat.observation.ChatObservationAutoConfiguration",
+        "spring.autoconfigure.exclude[6]=org.springframework.ai.autoconfigure.vectorstore.qdrant.QdrantVectorStoreAutoConfiguration",
+        "spring.autoconfigure.exclude[7]=org.springframework.ai.autoconfigure.embedding.openai.OpenAiEmbeddingAutoConfiguration",
+        "spring.autoconfigure.exclude[8]=org.springframework.ai.autoconfigure.retry.SpringAiRetryAutoConfiguration",
+        "spring.main.web-application-type=none",
+        "logging.level.org.springframework.security=OFF",
+        "logging.level.org.springframework.web=OFF",
+        "logging.level.org.springframework.ai=OFF"
+    }
+)
+public class CourseEmbeddingServiceTest {
+
+    @Autowired
+    private CourseEmbeddingService courseEmbeddingService;
+
+    @Test
+    public void testSearchCoursesByPreference() {
+        System.out.println("=== CourseEmbeddingService.searchCoursesByPreference 테스트 시작 ===");
+        
+        try {
+            // 기본 테스트 쿼리
+            String query = "웹프로그래밍";
+            int topK = 5;
+            
+            System.out.println("검색 쿼리: '" + query + "' (상위 " + topK + "개)");
+            System.out.println("=" + "=".repeat(50));
+            
+            // 실제 서비스 호출
+            List<Map<String, Object>> results = courseEmbeddingService.searchCoursesByPreference(query, topK);
+            
+            System.out.println("검색 완료: " + results.size() + "개 결과");
+            
+            if (results.isEmpty()) {
+                System.out.println("검색 결과가 없습니다.");
+                System.out.println("Qdrant 서버가 실행 중이지 않거나 데이터가 없을 수 있습니다.");
+                return;
+            }
+            
+            // 결과 출력
+            for (int i = 0; i < results.size(); i++) {
+                Map<String, Object> course = results.get(i);
+                System.out.println("\n결과 " + (i + 1) + ":");
+                System.out.println("  - 과목명: " + course.get("courseName"));
+                System.out.println("  - 과목코드: " + course.get("courseCode"));
+                System.out.println("  - 학점: " + course.get("credits"));
+                System.out.println("  - 개설학년: " + course.get("openGrade"));
+                System.out.println("  - 개설학기: " + course.get("openSemester"));
+                System.out.println("  - 설명: " + course.get("description"));
+                System.out.println("  - 트랙: " + course.get("tracks"));
+                System.out.println("  - 유사도 점수: " + course.get("score"));
+            }
+            
+            System.out.println("\n테스트 완료!");
+            
+        } catch (Exception e) {
+            System.err.println("테스트 실패: " + e.getMessage());
+            System.err.println("Qdrant 서버가 실행 중이지 않거나 OpenAI API 키가 설정되지 않았을 수 있습니다.");
+            e.printStackTrace();
+        }
+    }
+    
+    @Test
+    public void testSearchCoursesByPreferenceWithDifferentTopK() {
+        System.out.println("=== topK 값별 테스트 시작 ===");
+        
+        String query = "웹프로그래밍";
+        int[] topKValues = {3, 5, 10};
+        
+        for (int topK : topKValues) {
+            System.out.println("\n🔍 검색 쿼리: '" + query + "' (상위 " + topK + "개)");
+            System.out.println("=" + "=".repeat(40));
+            
+            try {
+                // 실제 서비스 호출
+                List<Map<String, Object>> results = courseEmbeddingService.searchCoursesByPreference(query, topK);
+                System.out.println("검색 완료: " + results.size() + "개 결과");
+                
+                if (!results.isEmpty()) {
+                    System.out.println("상위 3개 결과:");
+                    for (int i = 0; i < Math.min(3, results.size()); i++) {
+                        Map<String, Object> course = results.get(i);
+                        System.out.println("  " + (i + 1) + ". " + course.get("courseName") + 
+                                         " (점수: " + course.get("score") + ")");
+                    }
+                } else {
+                    System.out.println("⚠검색 결과가 없습니다.");
+                }
+                
+            } catch (Exception e) {
+                System.err.println("topK=" + topK + " 테스트 실패: " + e.getMessage());
+                e.printStackTrace();
+            }
+            
+            System.out.println("\n" + "-".repeat(50));
+        }
+    }
+    
+    @Test
+    public void testSearchCoursesByPreferenceEdgeCases() {
+        System.out.println("=== 엣지 케이스 테스트 시작 ===");
+        
+        String[] edgeCaseQueries = {
+            "웹프로그래밍",  // 정상 쿼리
+            "데이터베이스",  // 다른 과목
+            "존재하지않는과목명",  // 존재하지 않는 과목
+            "웹",  // 짧은 쿼리
+            "웹프로그래밍기초"  // 부분 일치
+        };
+        
+        for (String query : edgeCaseQueries) {
+            System.out.println("\n🔍 엣지 케이스: '" + query + "'");
+            System.out.println("=" + "=".repeat(30));
+            
+            try {
+                // 실제 서비스 호출
+                List<Map<String, Object>> results = courseEmbeddingService.searchCoursesByPreference(query, 3);
+                System.out.println("검색 완료: " + results.size() + "개 결과");
+                
+                if (!results.isEmpty()) {
+                    System.out.println("결과 요약:");
+                    for (int i = 0; i < Math.min(3, results.size()); i++) {
+                        Map<String, Object> course = results.get(i);
+                        System.out.println("  " + (i + 1) + ". " + course.get("courseName") + 
+                                         " (점수: " + course.get("score") + ")");
+                    }
+                } else {
+                    System.out.println("⚠검색 결과가 없습니다.");
+                }
+                
+            } catch (Exception e) {
+                System.err.println("엣지 케이스 테스트 실패: " + e.getMessage());
+                e.printStackTrace();
+            }
+            
+            System.out.println("\n" + "-".repeat(40));
+        }
+    }
+    
+    @Test
+    public void testServiceDependencyInjection() {
+        System.out.println("=== 의존성 주입 테스트 시작 ===");
+        
+        try {
+            if (courseEmbeddingService == null) {
+                System.out.println("❌ CourseEmbeddingService가 null입니다.");
+                System.out.println("💡 Spring Boot 컨텍스트 로딩에 실패했을 수 있습니다.");
+                return;
+            }
+            
+            System.out.println("courseEmbeddingService 의존성 주입 성공");
+            System.out.println("서비스 클래스: " + courseEmbeddingService.getClass().getName());
+            
+            // 메서드 존재 확인
+            try {
+                courseEmbeddingService.getClass().getMethod("searchCoursesByPreference", String.class, int.class);
+                System.out.println("searchCoursesByPreference 메서드 존재 확인");
+            } catch (NoSuchMethodException e) {
+                System.err.println("searchCoursesByPreference 메서드를 찾을 수 없습니다.");
+            }
+            
+            System.out.println("의존성 주입 테스트 완료!");
+            
+        } catch (Exception e) {
+            System.err.println("의존성 주입 테스트 실패: " + e.getMessage());
+            e.printStackTrace();
+        }
+    }
+}


### PR DESCRIPTION
### 🚀 Summary

<!-- A brief description of the issue. -->

rag 기반 ai추천 로드맵 생성 기능 v1

### ✨ Description

<!-- write down the work details and show the execution results. -->
<img width="730" height="351" alt="image" src="https://github.com/user-attachments/assets/d1a906ef-db06-4845-907e-beca2dbcca2d" />
<br>

### 현재 로직
'반드시 포함할 과목' 목록 확보 (규칙 기반 필터링)
- AI의 유사도 검색에 의존하지 않고, PostgreSQL DB에서 학생의 졸업을 위해 반드시 필요한 과목들을 먼저 찾아냄(전기, 전필)
백터db 검색 목록 확보 (유사도 검색)
- 이제 사용자의 주관적인 선호도를 만족시키기 위해 rag 사용
1,2 단계 리스트 통합 및 중복 제거
- 두 리스트에 중복되는 과목이 있을 수 있으므로, 중복을 제거하여 유일한 과목 목록을 만듦
해당 과목 json데이터와 llm에게 보냄. 프롬프팅은 계속적으로 발전시킬 예정

4-1 학기 과목 추천 잘 해주는 것을 볼 수 있음


### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #{34}
