### PR TITLE
Fix: 로그인, 크롤링 api 분리

### DIFF
--- a/src/main/java/grit/guidance/domain/user/controller/CrawlingController.java
+++ b/src/main/java/grit/guidance/domain/user/controller/CrawlingController.java
@@ -1,0 +1,63 @@
+package grit.guidance.domain.user.controller;
+
+import grit.guidance.domain.user.dto.ErrorResponse;
+import grit.guidance.domain.user.dto.LoginRequest;
+import grit.guidance.domain.user.service.UsersCrawlingService;
+import grit.guidance.domain.user.service.LoginService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+@Slf4j
+@Tag(name = "크롤링", description = "사용자 데이터 크롤링 관련 API")
+public class CrawlingController {
+
+    private final UsersCrawlingService crawlingService;
+    private final LoginService loginService;
+
+    @PostMapping("/crawling")
+    @Operation(summary = "신규 사용자 데이터 크롤링", description = "신규 사용자의 약관 동의 후 한성대 포털에서 학사 데이터를 크롤링하여 저장")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "크롤링 성공"),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청 (학번/비밀번호 오류)"),
+        @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    public ResponseEntity<?> crawlUserData(@RequestBody LoginRequest request) {
+        try {
+            log.info("크롤링 요청 시작: studentId={}", request.studentId());
+            
+            // 크롤링 실행
+            var hansungData = crawlingService.fetchHansungData(request.studentId(), request.password());
+            
+            // 크롤링된 데이터 저장/업데이트
+            loginService.saveOrUpdateAllUserData(request.studentId(), hansungData);
+            
+            log.info("크롤링 및 데이터 저장 완료: studentId={}", request.studentId());
+            
+            return ResponseEntity.ok().body(new CrawlingResponse(200, "크롤링이 완료되었습니다."));
+            
+        } catch (IllegalArgumentException e) {
+            log.warn("크롤링 실패 - 잘못된 인증: {}", e.getMessage());
+            ErrorResponse errorResponse = new ErrorResponse(400, e.getMessage());
+            return ResponseEntity.badRequest().body(errorResponse);
+        } catch (Exception e) {
+            log.error("크롤링 중 오류 발생: {}", e.getMessage(), e);
+            ErrorResponse errorResponse = new ErrorResponse(500, "크롤링 중 오류가 발생했습니다.");
+            return ResponseEntity.status(500).body(errorResponse);
+        }
+    }
+    
+    // 크롤링 응답 DTO
+    public record CrawlingResponse(
+        Integer status,
+        String message
+    ) {}
+}

--- a/src/main/java/grit/guidance/domain/user/controller/LoginController.java
+++ b/src/main/java/grit/guidance/domain/user/controller/LoginController.java
@@ -24,11 +24,11 @@ public class LoginController {
     private final LoginService loginService;
 
     @PostMapping("/login")
-    @Operation(summary = "로그인", description = "기존 사용자면 초기 화면 정보를 전달")
+    @Operation(summary = "로그인", description = "한성대 포털 로그인 검증 및 신규/기존 사용자 구분")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "201", description = "로그인 성공"),
+        @ApiResponse(responseCode = "200", description = "로그인 성공 - 신규/기존 사용자 정보 반환"),
         @ApiResponse(responseCode = "400", description = "잘못된 요청 (사용자 이름/비밀번호 누락 또는 잘못된 비밀번호)"),
-        @ApiResponse(responseCode = "404", description = "회원 정보를 찾을 수 없습니다")
+        @ApiResponse(responseCode = "500", description = "서버 오류")
     })
     public ResponseEntity<?> login(@RequestBody LoginRequest request, HttpServletResponse response) {
         try {
@@ -36,15 +36,15 @@ public class LoginController {
             clearExistingCookies(response);
             
             LoginResponse loginResponse = loginService.login(request);
-            return ResponseEntity.status(loginResponse.status()).body(loginResponse);
+            return ResponseEntity.ok(loginResponse);
         } catch (IllegalArgumentException e) {
             // 400 Bad Request
             ErrorResponse errorResponse = new ErrorResponse(400, e.getMessage());
             return ResponseEntity.badRequest().body(errorResponse);
-        } catch (RuntimeException e) {
-            // 404 Not Found
-            ErrorResponse errorResponse = new ErrorResponse(404, e.getMessage());
-            return ResponseEntity.status(404).body(errorResponse);
+        } catch (Exception e) {
+            // 500 Internal Server Error
+            ErrorResponse errorResponse = new ErrorResponse(500, "서버 오류가 발생했습니다.");
+            return ResponseEntity.status(500).body(errorResponse);
         }
     }
 

--- a/src/main/java/grit/guidance/domain/user/dto/LoginResponse.java
+++ b/src/main/java/grit/guidance/domain/user/dto/LoginResponse.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public record LoginResponse(
     @JsonProperty("status")
     Integer status,
+    @JsonProperty("is_new_user")
+    Boolean isNewUser,
     @JsonProperty("access_token")
     String accessToken
 ) {

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -16,3 +16,13 @@ spring:
     username: ${POSTGRES_USER:sa}
     password: ${POSTGRES_PASSWORD:1234}
     driver-class-name: org.postgresql.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: create
+    show-sql: true
+    properties:
+      hibernate:
+        highlight_sql: true
+        format_sql: true
+        dialect: org.hibernate.dialect.PostgreSQLDialect

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,12 +8,6 @@ spring:
     openai:
       api-key: ${OPENAI_API_KEY:}
 
-# OpenAI API 설정
-openai:
-  api:
-    key: ${OPENAI_API_KEY:}
-    url: ${OPENAI_API_URL:https://api.openai.com}
-
   jackson:
     property-naming-strategy: SNAKE_CASE
     serialization:
@@ -32,6 +26,12 @@ openai:
         highlight_sql: true
         format_sql: true
         dialect: org.hibernate.dialect.PostgreSQLDialect
+
+# OpenAI API 설정
+openai:
+  api:
+    key: ${OPENAI_API_KEY:}
+    url: ${OPENAI_API_URL:https://api.openai.com}
 
 management:
   endpoints:


### PR DESCRIPTION
### 🚀 Summary
로그인, 크롤링 api 분리

### ✨ Description
이제 로그인 할때 무조건 크롤링 안됩니다.
/api/users/login api는 아이디 비번 검증 및 신규 유저 여부 판단(db에 있는 학번인지)

## 1. 기존 유저일 경우
- /api/users/login api 만 호출해도 크롤링 조건에 맞으면 크롤링 실행
## 2. 신규 유저일 경우
- /api/users/login api 호출 후 사용자가 약관동의 버튼을 누르면
- /api/users/crawling api 호출해서 크롤링 실행
### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #{Issue Number}
