### PR TITLE
refactor: 유저테이블에 학년, 학기 속성 추가 / 이수과목 테이블의 이수 학년, 학기 정상화

### DIFF
--- a/src/main/java/grit/guidance/domain/user/dto/HansungDataResponse.java
+++ b/src/main/java/grit/guidance/domain/user/dto/HansungDataResponse.java
@@ -1,5 +1,6 @@
 package grit.guidance.domain.user.dto;
 
+import grit.guidance.domain.course.entity.Semester;
 import java.util.List;
 
 // 최종 크롤링 결과를 담는 DTO
@@ -8,5 +9,7 @@ public record HansungDataResponse(
         TotalGradeResponse grades,
         MajorRequiredCreditsResponse majorCredits, // 이 줄을 추가합니다.
         List<String> enrolledCourseNames,
-        String timetableJson
+        String timetableJson,
+        Integer grade,
+        Semester semester
 ) {}

--- a/src/main/java/grit/guidance/domain/user/entity/Users.java
+++ b/src/main/java/grit/guidance/domain/user/entity/Users.java
@@ -1,5 +1,6 @@
 package grit.guidance.domain.user.entity;
 
+import grit.guidance.domain.course.entity.Semester;
 import grit.guidance.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -42,6 +43,13 @@ public class Users extends BaseEntity {
     @Column(name = "last_crawl_time")
     private LocalDateTime lastCrawlTime; // 마지막 크롤링 시간
 
+    @Column(name = "grade", nullable = false)
+    private Integer grade; // 학년
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "semester", nullable = false)
+    private Semester semester; // 학기
+
     // 1:1 관계 - users와 setting (양방향)
     @OneToOne(mappedBy = "users", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private Setting setting;
@@ -59,12 +67,14 @@ public class Users extends BaseEntity {
     private List<FavoriteCourse> favoriteCourses = new ArrayList<>();
 
     @Builder
-    public Users(String studentId, BigDecimal gpa, Integer earnedCredits, String timetable, LocalDateTime lastCrawlTime) {
+    public Users(String studentId, BigDecimal gpa, Integer earnedCredits, String timetable, LocalDateTime lastCrawlTime, Integer grade, Semester semester) {
         this.studentId = studentId;
         this.gpa = gpa != null ? gpa : BigDecimal.ZERO;
         this.earnedCredits = earnedCredits != null ? earnedCredits : 0;
         this.timetable = timetable;
         this.lastCrawlTime = lastCrawlTime;
+        this.grade = grade != null ? grade : 1;
+        this.semester = semester != null ? semester : Semester.FIRST;
     }
 
     // 비즈니스 메서드
@@ -88,6 +98,20 @@ public class Users extends BaseEntity {
     
     public void updateLastCrawlTime() {
         this.lastCrawlTime = LocalDateTime.now();
+    }
+
+    public void updateGrade(Integer grade) {
+        if (grade < 1 || grade > 4) {
+            throw new IllegalArgumentException("학년은 1-4 범위여야 합니다.");
+        }
+        this.grade = grade;
+    }
+
+    public void updateSemester(Semester semester) {
+        if (semester == null) {
+            throw new IllegalArgumentException("학기는 null일 수 없습니다.");
+        }
+        this.semester = semester;
     }
 }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   application:
     name: session
   profiles:
-    active: ${SPRING_PROFILES_ACTIVE:dev}
+    active: ${SPRING_PROFILES_ACTIVE:local}
   
   ai:
     openai:
@@ -19,7 +19,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create-drop
     show-sql: true
     properties:
       hibernate:


### PR DESCRIPTION
### 🚀 Summary
유저테이블에 학년, 학기 속성 추가 / 이수과목 테이블의 이수 학년, 학기 정상화

### ✨ Description
유저의 학년: 크롤링
유저의 학기: 날짜보고 계산

이수과목 테이블의 이수 학년 학기가 해당 과목의 개설 학년으로 들어가던 문제를 고쳤습니다.

### 🎲 Issue Number
close #62 
